### PR TITLE
listen for MOVED_TO events in doit auto

### DIFF
--- a/doit/filewatch.py
+++ b/doit/filewatch.py
@@ -97,7 +97,7 @@ class FileModifyWatcher(object):
         event_handler = EventHandler()
         notifier = pyinotify.Notifier(watch_manager, event_handler)
 
-        mask = pyinotify.IN_CLOSE_WRITE
+        mask = pyinotify.IN_CLOSE_WRITE | pyinotify.IN_MOVED_TO
         for watch_this in self.watch_dirs:
             watch_manager.add_watch(watch_this, mask)
 


### PR DESCRIPTION
If a file is replaced it does change too.

For the OS X code path this change should be applied as well.  From a quick search fsevents.IN_MOVED_TO seems to exist but I have not verified it.

Btw. actually the safe way to "save" a file is to create a temp file and then move it over the original. So no other concurrently running process could read only half of it or in case of power failure the file would not corrupt.