### PR TITLE
Allow to customize how file_dep are checked.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@
  * Vincent Férotin - vincent <dot> ferotin <at> gmail <dot> com
  * Chris Warrick - Kwpolska - http://chriswarrick.com/
  * Ronan Le Gallic - rolegic <at> gmail <dot> com
+ * Simon Conseil - contact <at> saimon <dot> org

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -44,7 +44,8 @@ This flag is valid for all sub-commands.
     $ doit -f release.py
 
 
-*doit* can seek for the ``dodo.py`` file on parent folders if the the option ``--seek-file`` is specified.
+*doit* can seek for the ``dodo.py`` file on parent folders if the option
+``--seek-file`` is specified.
 
 
 as an executable file
@@ -277,7 +278,7 @@ check_file_uptodate
 `doit` provides different options to check if files are up to date.
 Use the option ``--check_file_uptodate`` to choose:
 
- * default: use the timestamp, size and md5sum of the file.
+ * md5: use the md5sum of the file.
  * timestamp: use only the timestamp and size.
 
 .. code-block:: console
@@ -291,18 +292,18 @@ custom check_file_uptodate
 It is possible to define your own custom up to date checker. Check the code on
 `doit/dependency.py
 <https://github.com/pydoit/doit/blob/master/doit/dependency.py>`_ ... It is
-easy to get started by sub-classing the default reporter as shown below. The
-custom reporter must be configured using DOIT_CONFIG dict.
+easy to get started by sub-classing ``FileChangedChecker`` as shown below. The
+custom checker must be configured using DOIT_CONFIG dict.
 
 .. code-block:: python
 
-    from doit.dependency import BaseChecker
+    from doit.dependency import FileChangedChecker
 
-    class MyChecker(BaseChecker):
+    class MyChecker(FileChangedChecker):
         """With this checker, files are always out of date."""
         def check_modified(self, file_path, state):
             return True
-        def save_state(self, task, dep):
+        def get_state(self, task, dep, current_state):
             pass
 
     DOIT_CONFIG = {'check_file_uptodate': MyChecker}

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -303,7 +303,7 @@ custom checker must be configured using DOIT_CONFIG dict.
         """With this checker, files are always out of date."""
         def check_modified(self, file_path, state):
             return True
-        def get_state(self, task, dep, current_state):
+        def get_state(self, dep, current_state):
             pass
 
     DOIT_CONFIG = {'check_file_uptodate': MyChecker}

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -271,6 +271,42 @@ from a task while it is being executed,
 this is controlled by the ``verbosity`` param.
 
 
+check_file_uptodate
+-------------------
+
+`doit` provides different options to check if files are up to date.
+Use the option ``--check_file_uptodate`` to choose:
+
+ * default: use the timestamp, size and md5sum of the file.
+ * timestamp: use only the timestamp and size.
+
+.. code-block:: console
+
+    $ doit --reporter timestamp
+
+
+custom check_file_uptodate
+--------------------------
+
+It is possible to define your own custom up to date checker. Check the code on
+`doit/dependency.py
+<https://github.com/pydoit/doit/blob/master/doit/dependency.py>`_ ... It is
+easy to get started by sub-classing the default reporter as shown below. The
+custom reporter must be configured using DOIT_CONFIG dict.
+
+.. code-block:: python
+
+    from doit.dependency import BaseChecker
+
+    class MyChecker(BaseChecker):
+        """With this checker, files are always out of date."""
+        def check_modified(self, file_path, state):
+            return True
+        def save_state(self, task, dep):
+            pass
+
+    DOIT_CONFIG = {'check_file_uptodate': MyChecker}
+
 
 output-file
 ------------

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -275,15 +275,15 @@ this is controlled by the ``verbosity`` param.
 check_file_uptodate
 -------------------
 
-`doit` provides different options to check if files are up to date.
-Use the option ``--check_file_uptodate`` to choose:
+`doit` provides different options to check if dependency files are up to date
+(see :ref:`file-dep`).  Use the option ``--check_file_uptodate`` to choose:
 
- * md5: use the md5sum of the file.
- * timestamp: use only the timestamp and size.
+ * md5: use the md5sum.
+ * timestamp: use the timestamp.
 
 .. code-block:: console
 
-    $ doit --reporter timestamp
+    $ doit --check_file_uptodate timestamp
 
 
 custom check_file_uptodate

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -267,6 +267,7 @@ The execution of the task's actions is skipped.
 Note the ``--`` (2 dashes, one space) on the command output on the second
 time it is executed. It means, this task was up-to-date and not executed.
 
+.. _file-dep:
 
 file_dep (file dependency)
 -----------------------------

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -271,7 +271,6 @@ class DoitCmdBase(Command):
         self.dep_class = backend_map.get(params['backend'])
         params['pos_args'] = args # hack
         params['continue_'] = params.get('continue') # hack
-        params['modified_checkers'] = self.config.get('modified_checkers') # hack
 
         # magic - create dict based on signature of _execute method
         args_name = inspect.getargspec(self._execute)[0]

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -260,8 +260,8 @@ class DoitCmdBase(Command):
         if minversion:
             if version_tuple(minversion) > version_tuple(version.VERSION):
                 msg = ('Please update doit. '
-                'Minimum version required is {required}. '
-                'You are using {actual}. ')
+                       'Minimum version required is {required}. '
+                       'You are using {actual}. ')
                 raise InvalidDodoFile(msg.format(required=minversion,
                                                  actual=version.VERSION))
 
@@ -271,6 +271,7 @@ class DoitCmdBase(Command):
         self.dep_class = backend_map.get(params['backend'])
         params['pos_args'] = args # hack
         params['continue_'] = params.get('continue') # hack
+        params['modified_checkers'] = self.config.get('modified_checkers') # hack
 
         # magic - create dict based on signature of _execute method
         args_name = inspect.getargspec(self._execute)[0]

--- a/doit/cmd_run.py
+++ b/doit/cmd_run.py
@@ -100,11 +100,11 @@ opt_check_file_uptodate = {
     'short': '',
     'long': 'check_file_uptodate',
     'type': str,
-    'default': 'default',
+    'default': 'md5',
     'help': """\
 Choose how to check if files have been modified. Available:
-'default': use timestamp, size and md5sum
-'timestamp': use only timestamp and size
+'md5': use the md5sum
+'timestamp': use the timestamp
 """
 }
 
@@ -148,7 +148,7 @@ class Run(DoitCmdBase):
     def _execute(self, outfile,
                  verbosity=None, always=False, continue_=False,
                  reporter='default', num_process=0, par_type='process',
-                 single=False, check_file_uptodate='default'):
+                 single=False, check_file_uptodate='md5'):
         """
         @param reporter:
                (str) one of provided reporters or ...

--- a/doit/cmd_run.py
+++ b/doit/cmd_run.py
@@ -133,7 +133,7 @@ class Run(DoitCmdBase):
     def _execute(self, outfile,
                  verbosity=None, always=False, continue_=False,
                  reporter='default', num_process=0, par_type='process',
-                 single=False):
+                 single=False, modified_checkers=None):
         """
         @param reporter:
                (str) one of provided reporters or ...
@@ -185,14 +185,13 @@ class Run(DoitCmdBase):
         try:
             # FIXME stderr will be shown twice in case of task error/failure
             if isinstance(reporter_cls, type):
-                reporter_obj = reporter_cls(outstream, {'show_out':show_out,
+                reporter_obj = reporter_cls(outstream, {'show_out': show_out,
                                                         'show_err': True})
             else: # also accepts reporter instances
                 reporter_obj = reporter_cls
 
-
             run_args = [self.dep_class, self.dep_file, reporter_obj,
-                        continue_, always, verbosity]
+                        continue_, always, verbosity, modified_checkers]
 
             if num_process == 0:
                 RunnerClass = Runner

--- a/doit/cmd_run.py
+++ b/doit/cmd_run.py
@@ -174,10 +174,10 @@ class Run(DoitCmdBase):
         # reporter
         if isinstance(reporter, six.string_types):
             if reporter not in REPORTERS:
-                msg = ("No reporter named '%s'."
+                msg = ("No reporter named '{}'."
                        " Type 'doit help run' to see a list "
                        "of available reporters.")
-                raise InvalidCommand(msg % reporter)
+                raise InvalidCommand(msg.format(reporter))
             reporter_cls = REPORTERS[reporter]
         else:
             # user defined class
@@ -186,10 +186,10 @@ class Run(DoitCmdBase):
         # check_file_uptodate
         if isinstance(check_file_uptodate, six.string_types):
             if check_file_uptodate not in CHECKERS:
-                msg = ("No check_file_uptodate named '%s'."
+                msg = ("No check_file_uptodate named '{}'."
                        " Type 'doit help run' to see a list "
                        "of available checkers.")
-                raise InvalidCommand(msg % check_file_uptodate)
+                raise InvalidCommand(msg.format(check_file_uptodate))
             checker_cls = CHECKERS[check_file_uptodate]
         else:
             # user defined class

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -350,7 +350,7 @@ class FileChangedChecker(object):
         @returns (bool): True if dep is modified
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_state(self, dep, current_state):
         """Compute the state of a task after it has been successfuly executed.
@@ -361,7 +361,7 @@ class FileChangedChecker(object):
         @returns (tuple): the new state. Return None if the state is unchanged.
 
         """
-        pass
+        raise NotImplementedError()
 
 
 class MD5Checker(FileChangedChecker):

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -338,7 +338,7 @@ class SqliteDB(object):
         self._conn.execute('delete from doit')
 
 
-class BaseChecker(object):
+class FileChangedChecker(object):
     """Base Checker that must be inherited."""
 
     def __init__(self, backend):
@@ -360,7 +360,7 @@ class BaseChecker(object):
         pass
 
 
-class DefaultChecker(BaseChecker):
+class DefaultChecker(FileChangedChecker):
     """Default checker. Use the timestamp, size and md5sum."""
 
     def check_modified(self, file_path, state):
@@ -397,7 +397,7 @@ class DefaultChecker(BaseChecker):
         self._set(task.name, dep, (timestamp, size, md5))
 
 
-class TimestampChecker(BaseChecker):
+class TimestampChecker(FileChangedChecker):
     """Checker that use only the timestamp, size."""
 
     def check_modified(self, file_path, state):

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -339,7 +339,7 @@ class SqliteDB(object):
 
 
 class FileChangedChecker(object):
-    """Base Checker that must be inherited."""
+    """Base checker for dependencies, must be inherited."""
 
     def check_modified(self, file_path, state):
         """Check if file in file_path is modified from previous "state".
@@ -361,7 +361,7 @@ class FileChangedChecker(object):
 
 
 class MD5Checker(FileChangedChecker):
-    """MD5 checker. Use the timestamp, size and md5sum."""
+    """MD5 checker, uses the md5sum."""
 
     def check_modified(self, file_path, state):
         """Check if file in file_path is modified from previous "state".
@@ -404,7 +404,7 @@ class MD5Checker(FileChangedChecker):
 
 
 class TimestampChecker(FileChangedChecker):
-    """Checker that use only the timestamp, size."""
+    """Checker that use only the timestamp."""
 
     def check_modified(self, file_path, state):
         try:

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -374,7 +374,8 @@ class MD5Checker(FileChangedChecker):
         try:
             file_stat = os.stat(file_path)
         except OSError:
-            raise Exception("Dependent file '%s' does not exist." % file_path)
+            raise Exception("Dependent file '{}' does not exist."
+                            .format(file_path))
 
         if state is None:
             return True
@@ -409,26 +410,19 @@ class TimestampChecker(FileChangedChecker):
 
     def check_modified(self, file_path, state):
         try:
-            file_stat = os.stat(file_path)
+            mtime = os.path.getmtime(file_path)
         except OSError:
-            raise Exception("Dependent file '%s' does not exist." % file_path)
+            raise Exception("Dependent file '{}' does not exist."
+                            .format(file_path))
 
         if state is None:
             return True
 
-        timestamp, size, _ = state
-
-        # 1 - if timestamp is not modified file is the same
-        if file_stat.st_mtime == timestamp:
-            return False
-
-        # 2 - if size is different file is modified
-        return file_stat.st_size != size
+        timestamp, _, _ = state
+        return mtime != timestamp
 
     def save_state(self, task, dep):
-        timestamp = os.path.getmtime(dep)
-        size = os.path.getsize(dep)
-        self._set(task.name, dep, (timestamp, size, None))
+        self._set(task.name, dep, (os.path.getmtime(dep), None, None))
 
 
 # name of checkers class available

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -348,14 +348,18 @@ class FileChangedChecker(object):
         @param state (tuple): state that was previously saved with
             ``get_state``
         @returns (bool): True if dep is modified
+
         """
         pass
 
-    def get_state(self, task, dep, current_state):
+    def get_state(self, dep, current_state):
         """Compute the state of a task after it has been successfuly executed.
 
-        @param task (Task): the task object.
         @param dep (str): path of the dependency file.
+        @param current_state (tuple): the current state, saved from a previous
+            execution of the task (None if the task was never run).
+        @returns (tuple): the new state. Return None if the state is unchanged.
+
         """
         pass
 
@@ -392,7 +396,7 @@ class MD5Checker(FileChangedChecker):
         # 3 - check md5
         return file_md5 != get_file_md5(file_path)
 
-    def get_state(self, task, dep, current_state):
+    def get_state(self, dep, current_state):
         timestamp = os.path.getmtime(dep)
         # time optimization. if dep is already saved with current
         # timestamp skip calculating md5
@@ -418,7 +422,7 @@ class TimestampChecker(FileChangedChecker):
 
         return mtime != state
 
-    def get_state(self, task, dep, current_state):
+    def get_state(self, dep, current_state):
         return os.path.getmtime(dep)
 
 
@@ -477,8 +481,7 @@ class DependencyBase(object):
         # file-dep
         self._set(task.name, 'checker:', self.checker.__class__.__name__)
         for dep in task.file_dep:
-            state = self.checker.get_state(task, dep,
-                                           self._get(task.name, dep))
+            state = self.checker.get_state(dep, self._get(task.name, dep))
             if state is not None:
                 self._set(task.name, dep, state)
 

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -350,7 +350,8 @@ class FileChangedChecker(object):
         """Check if file in file_path is modified from previous "state".
 
         @param file_path (string): file path
-        @param state (tuple), timestamp, size, md5
+        @param state (tuple): state that was previously saved with
+            ``save_state``
         @returns (bool): True if dep is modified
         """
         pass
@@ -360,10 +361,16 @@ class FileChangedChecker(object):
         pass
 
 
-class DefaultChecker(FileChangedChecker):
-    """Default checker. Use the timestamp, size and md5sum."""
+class MD5Checker(FileChangedChecker):
+    """MD5 checker. Use the timestamp, size and md5sum."""
 
     def check_modified(self, file_path, state):
+        """Check if file in file_path is modified from previous "state".
+
+        @param file_path (string): file path
+        @param state (tuple): timestamp, size, md5
+        @returns (bool): True if dep is modified
+        """
         try:
             file_stat = os.stat(file_path)
         except OSError:
@@ -425,7 +432,7 @@ class TimestampChecker(FileChangedChecker):
 
 
 # name of checkers class available
-CHECKERS = {'default': DefaultChecker,
+CHECKERS = {'md5': MD5Checker,
             'timestamp': TimestampChecker}
 
 
@@ -446,7 +453,7 @@ class DependencyBase(object):
 
     def __init__(self, backend, checker_cls=None):
         self._closed = False
-        self.checker = (checker_cls or DefaultChecker)(backend)
+        self.checker = (checker_cls or MD5Checker)(backend)
         self.backend = backend
         self._set = self.backend.set
         self._get = self.backend.get
@@ -497,7 +504,7 @@ class DependencyBase(object):
         """
         if not self._in(task_id):
             # FIXME do not use generic exception
-            raise Exception("taskid '%s' has no computed v, DefaultCheckeralue!" % task_id)
+            raise Exception("taskid '%s' has no computed value!" % task_id)
         values = self.get_values(task_id)
         if key_name not in values:
             msg = "Invalid arg name. Task '%s' has no value for '%s'."

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -29,14 +29,15 @@ class Runner(object):
 
     """
     def __init__(self, dep_class, dependency_file, reporter, continue_=False,
-                 always_execute=False, verbosity=0):
+                 always_execute=False, verbosity=0, modified_checkers=None):
         """@param dependency_file: (string) file path of the db file
         @param reporter: reporter object to be used
         @param continue_: (bool) execute all tasks even after a task failure
         @param always_execute: (bool) execute even if up-to-date or ignored
         @param verbosity: (int) 0,1,2 see Task.execute
         """
-        self.dep_manager = dep_class(dependency_file)
+        self.dep_manager = dep_class(dependency_file,
+                                     modified_checkers=modified_checkers)
         self.reporter = reporter
         self.continue_ = continue_
         self.always_execute = always_execute
@@ -321,9 +322,10 @@ class MRunner(Runner):
             return True
 
     def __init__(self, dep_class, dependency_file, reporter, continue_=False,
-                 always_execute=False, verbosity=0, num_process=1):
+                 always_execute=False, verbosity=0, modified_checkers=None,
+                 num_process=1):
         Runner.__init__(self, dep_class, dependency_file, reporter, continue_,
-                        always_execute, verbosity)
+                        always_execute, verbosity, modified_checkers)
         self.num_process = num_process
 
         self.free_proc = 0   # number of free process

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -28,16 +28,15 @@ class Runner(object):
       finish()
 
     """
-    def __init__(self, dep_class, dependency_file, reporter, continue_=False,
-                 always_execute=False, verbosity=0, modified_checkers=None):
+    def __init__(self, dep_class, dependency_file, reporter, checker_cls=None,
+                 continue_=False, always_execute=False, verbosity=0):
         """@param dependency_file: (string) file path of the db file
         @param reporter: reporter object to be used
         @param continue_: (bool) execute all tasks even after a task failure
         @param always_execute: (bool) execute even if up-to-date or ignored
         @param verbosity: (int) 0,1,2 see Task.execute
         """
-        self.dep_manager = dep_class(dependency_file,
-                                     modified_checkers=modified_checkers)
+        self.dep_manager = dep_class(dependency_file, checker_cls=checker_cls)
         self.reporter = reporter
         self.continue_ = continue_
         self.always_execute = always_execute
@@ -321,11 +320,12 @@ class MRunner(Runner):
         else:
             return True
 
-    def __init__(self, dep_class, dependency_file, reporter, continue_=False,
-                 always_execute=False, verbosity=0, modified_checkers=None,
+    def __init__(self, dep_class, dependency_file, reporter, checker_cls=None,
+                 continue_=False, always_execute=False, verbosity=0,
                  num_process=1):
-        Runner.__init__(self, dep_class, dependency_file, reporter, continue_,
-                        always_execute, verbosity, modified_checkers)
+        Runner.__init__(self, dep_class, dependency_file, reporter,
+                        checker_cls=None, continue_=continue_,
+                        always_execute=always_execute, verbosity=verbosity)
         self.num_process = num_process
 
         self.free_proc = 0   # number of free process

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -8,7 +8,7 @@ from doit.exceptions import InvalidCommand
 from doit.task import Task
 from doit import reporter, runner
 from doit.cmd_run import Run
-from doit.dependency import FileChangedChecker
+from doit.dependency import MD5Checker
 from tests.conftest import tasks_sample
 
 
@@ -139,10 +139,8 @@ class TestCmdRun(object):
                       output, check_file_uptodate="i dont exist")
 
     def testCustomChecker(self, depfile_name):
-
-        class MyChecker(FileChangedChecker):
-            def check_modified(self, file_path, state):
-                return True
+        class MyChecker(MD5Checker):
+            pass
 
         output = StringIO()
         cmd_run = Run(backend='dbm', dep_file=depfile_name,

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -330,6 +330,18 @@ class TestTimestampChecker(object):
 
         pdepfile.checker = TimestampChecker()
         assert 'run' == pdepfile.get_status(t1, {})
+        pdepfile.save_success(t1)
+        assert 'up-to-date' == pdepfile.get_status(t1, {})
+
+    def test_file_dependency_not_exist(self, pdepfile):
+        pdepfile.checker = TimestampChecker()
+        filePath = get_abspath("data/dependency_not_exist")
+        t1 = Task("t1", None, [filePath])
+        pytest.raises(Exception, pdepfile.get_status, t1, {})
+
+    def test_None(self, dependency1):
+        checker = TimestampChecker()
+        assert checker.check_modified(dependency1, None)
 
 
 class TestGetStatus(object):

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -302,12 +302,6 @@ class TestCheckModified(object):
                                               (timestamp+1, size, md5))
         assert dep.checker.check_modified(dependency1, (timestamp+1, size, ''))
 
-    def test_without_md5(self, dependency1):
-        dep = DependencyBase(Mock(), checker_cls=TimestampChecker)
-        md5 = get_file_md5(dependency1)
-        # correct md5 but don't use it
-        assert dep.checker.check_modified(dependency1, (0, 0, md5))
-
     def test_custom_checker(self, pdepfile, dependency1):
         class MyChecker(FileChangedChecker):
             """With this checker, files are always out of date."""
@@ -319,6 +313,22 @@ class TestCheckModified(object):
         pdepfile.save_success(t1)
         assert pdepfile.checker.check_modified(dependency1, (0, 0, None))
         assert 'run' == pdepfile.get_status(t1, {})
+        assert 'run' == pdepfile.get_status(t1, {})
+
+
+class TestTimestampChecker(object):
+    def test_timestamp(self, pdepfile, dependency1):
+        pdepfile.checker = TimestampChecker()
+        assert pdepfile.checker.check_modified(dependency1, 0)
+        assert not pdepfile.checker.check_modified(
+            dependency1, os.path.getmtime(dependency1))
+
+    def test_change_checker(self, pdepfile, dependency1):
+        t1 = Task("taskId_X", None, [dependency1])
+        pdepfile.save_success(t1)
+        assert 'up-to-date' == pdepfile.get_status(t1, {})
+
+        pdepfile.checker = TimestampChecker()
         assert 'run' == pdepfile.get_status(t1, {})
 
 

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -11,7 +11,7 @@ from doit.task import Task
 from doit.dependency import get_md5, get_file_md5
 from doit.dependency import DbmDB, DatabaseException, UptodateCalculator
 from doit.dependency import JsonDependency, DbmDependency, SqliteDependency
-from doit.dependency import DependencyBase, TimestampChecker, BaseChecker
+from doit.dependency import DependencyBase, TimestampChecker, FileChangedChecker
 from .conftest import get_abspath, depfile
 
 #path to test folder
@@ -19,7 +19,7 @@ TEST_PATH = os.path.dirname(__file__)
 PROGRAM = "python %s/sample_process.py" % TEST_PATH
 
 
-class MyChecker(BaseChecker):
+class MyChecker(FileChangedChecker):
     """With this checker, files are always out of date."""
 
     def check_modified(self, file_path, state):

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -19,16 +19,6 @@ TEST_PATH = os.path.dirname(__file__)
 PROGRAM = "python %s/sample_process.py" % TEST_PATH
 
 
-class MyChecker(FileChangedChecker):
-    """With this checker, files are always out of date."""
-
-    def check_modified(self, file_path, state):
-        return True
-
-    def save_state(self, task, dep):
-        pass
-
-
 def test_unicode_md5():
     data = six.u("我")
     # no exception is raised
@@ -319,7 +309,12 @@ class TestCheckModified(object):
         assert dep.checker.check_modified(dependency1, (0, 0, md5))
 
     def test_custom_checker(self, pdepfile, dependency1):
-        pdepfile.checker = MyChecker(pdepfile.backend)
+        class MyChecker(FileChangedChecker):
+            """With this checker, files are always out of date."""
+            def check_modified(self, file_path, state):
+                return True
+
+        pdepfile.checker = MyChecker()
         t1 = Task("taskId_X", None, [dependency1])
         pdepfile.save_success(t1)
         assert pdepfile.checker.check_modified(dependency1, (0, 0, None))

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -302,11 +302,25 @@ class TestCheckModified(object):
                                               (timestamp+1, size, md5))
         assert dep.checker.check_modified(dependency1, (timestamp+1, size, ''))
 
+
+class TestCustomChecker(object):
+
+    def test_not_implemented(self, dependency1):
+        class MyChecker(FileChangedChecker):
+            pass
+
+        checker = MyChecker()
+        pytest.raises(NotImplementedError, checker.get_state, None, None)
+        pytest.raises(NotImplementedError, checker.check_modified, None, None)
+
     def test_custom_checker(self, pdepfile, dependency1):
         class MyChecker(FileChangedChecker):
             """With this checker, files are always out of date."""
             def check_modified(self, file_path, state):
                 return True
+
+            def get_state(self, dep, current_state):
+                return ()
 
         pdepfile.checker = MyChecker()
         t1 = Task("taskId_X", None, [dependency1])


### PR DESCRIPTION
Following #22, I tried to do something, but I don't understand clearly how the config / params are handled. Comments welcome ;)

Add a `modified_checkers` option which allows to choose how file_dep are checked
to know if they are modified. `modified_checkers` is a dict with boolean values
for each checker:
```
DOIT_CONFIG = {
    'modified_checkers' : {
        'timestamp': True,
        'size': True,
        'md5': True
    }
}
```