### PR TITLE
Display dependenciess-graph using networkx & matplotlib

### DIFF
--- a/doit/cmd_list.py
+++ b/doit/cmd_list.py
@@ -46,6 +46,15 @@ opt_list_dependencies = {
              "(file dependencies only)")
     }
 
+opt_disp_graph = {
+    'name': 'disp_graph',
+    'short': 'g',
+    'long': 'graph',
+    'type': bool,
+    'default': False,
+    'help': "display a dependency graph with selected (or all) tasks using matplotlib"
+    }
+
 opt_template = {
     'name': 'template',
     'short': '',
@@ -62,23 +71,29 @@ class List(DoitCmdBase):
     doc_description = None
 
     cmd_options = (opt_listall, opt_list_quiet, opt_list_status,
-                   opt_list_private, opt_list_dependencies, opt_template)
+                   opt_list_private, opt_list_dependencies,
+                   opt_disp_graph, opt_template)
 
 
     STATUS_MAP = {'ignore': 'I', 'up-to-date': 'U', 'run': 'R'}
 
+
+    def _get_task_status(self, task):
+        """print a single task"""
+        # FIXME group task status is never up-to-date
+        if self.dep_manager.status_is_ignore(task):
+            task_status = 'ignore'
+        else:
+            # FIXME:'ignore' handling is ugly
+            task_status = self.dep_manager.get_status(task, None)
+        return self.STATUS_MAP[task_status]
 
     def _print_task(self, template, task, status, list_deps):
         """print a single task"""
         line_data = {'name': task.name, 'doc':task.doc}
         # FIXME group task status is never up-to-date
         if status:
-            # FIXME: 'ignore' handling is ugly
-            if self.dep_manager.status_is_ignore(task):
-                task_status = 'ignore'
-            else:
-                task_status = self.dep_manager.get_status(task, None)
-            line_data['status'] = self.STATUS_MAP[task_status]
+            line_data['status'] = self._get_task_status(task)
 
         self.outstream.write(template.format(**line_data))
 
@@ -112,9 +127,104 @@ class List(DoitCmdBase):
             print_list.append(task)
         return print_list
 
+    def _prepare_graph(self, all_tasks_map, filter_task_names):
+        """
+        Construct a *networkx* graph of nodes (Tasks/Files/Wildcards) and their dependencies (file/wildcard, task/setup,calc).
+
+        :param filter_task_names: If None, graph includes all tasks
+        """
+        import networkx as nx
+
+        task_attributes = {
+            'task_dep':     {'node_type':'task'},
+            'setup_tasks':  {'node_type':'task', 'edge_type':'setup_dep'},
+            'calc_dep':     {'node_type':'task'},
+            'file_dep':     {'node_type':'file'},
+            'wild_dep':     {'node_type':'wildcard'},
+        }
+
+        graph = nx.MultiDiGraph()
+        def add_graph_node(node, node_type, add_deps=False):
+            if node in graph:
+                return
+            if node_type != 'task':
+                graph.add_node(node, type=node_type)
+            else:
+                task = all_tasks_map[node]
+                graph.add_node(node, type=node_type,
+                               is_subtask=task.is_subtask,
+                               status=self._get_task_status(task))
+                if add_deps:
+                    for attr, attr_kws in task_attributes.items():
+                        for dname in getattr(task, attr):
+                            dig_deps = filter_task_names is None or dname in filter_task_names
+                            add_graph_node(dname, attr_kws['node_type'], add_deps=dig_deps)
+                            graph.add_edge(node, dname, type=attr_kws.get('edge_type', attr))
+                    ## Above loop cannot add targets
+                    #    because they are reversed.
+                    #
+                    for dname in task.targets:
+                        add_graph_node(dname, 'file')
+                        graph.add_edge(dname, node, type='target')
+
+        ## Add all named-tasks
+        #    and their dependencies.
+        #
+        for tname in (filter_task_names or all_tasks_map.keys()):
+            add_graph_node(tname, 'task', add_deps=True)
+
+        return graph
+
+    def _display_graph(self, graph, temlate):
+        import networkx as nx
+        from matplotlib import pyplot as plt
+
+        def find_node_attr(g, attr, value):
+            return [n for n,d in g.nodes(data=True) if d[attr] == value]
+        def find_edge_attr(g, attr, value):
+            return [(n1,n2) for n1,n2,d in g.edges(data=True) if d[attr] == value]
+
+        node_type_styles = {
+            'task':     { 'node_color': 'g', 'node_shape': 'o'},
+            'file':     { 'node_color': 'b', 'node_shape': 's'},
+            'wildcard': { 'node_color': 'c', 'node_shape': 'd'},
+        }
+        dep_type_styles = {
+            ## TASK-dependencies
+            'task_dep': { 'edge_color': 'k', 'style': 'dotted'},
+            'setup_dep':{ 'edge_color': 'm', },
+            'calc_dep': { 'edge_color': 'g', },
+            ## DATA-dependencies
+            'file_dep': { 'edge_color': 'b', },
+            'wild_dep': { 'edge_color': 'b', 'style': 'dashed'},
+            'target':   { 'edge_color': 'c', },
+        }
+
+        pos = nx.spring_layout(graph, dim=2)
+        for item_type, style in node_type_styles.items():
+            nodes = find_node_attr(graph, 'type', item_type)
+            nx.draw_networkx_nodes(graph, pos, nodes,
+                                   label=item_type,
+                                   **style)
+        for item_type, style in dep_type_styles.items():
+            edges = find_edge_attr(graph, 'type', item_type)
+            nx.draw_networkx_edges(graph, pos, edges,
+                                   label=item_type, alpha=0.4,
+                                   **style)
+        nx.draw_networkx_labels(graph, pos) ## TODO: Use template for labels.
+        ax = plt.gca()
+        ax.legend(framealpha=0.5)
+        ax.set_frame_on(False)
+        ax.get_xaxis().set_visible(False)
+        ax.get_yaxis().set_visible(False)
+        plt.subplots_adjust(0,0,1,1)
+
+        plt.show()
+
 
     def _execute(self, subtasks=False, quiet=True, status=False,
-                 private=False, list_deps=False, template=None, pos_args=None):
+                 private=False, list_deps=False, template=None,
+                 disp_graph=False, pos_args=None):
         """List task generators, in the order they were defined.
         """
         filter_tasks = pos_args
@@ -131,20 +241,29 @@ class List(DoitCmdBase):
         if not private:
             print_list = [t for t in print_list if not t.name.startswith('_')]
 
-        # set template
-        if template is None:
-            max_name_len = 0
-            if print_list:
-                max_name_len = max(len(t.name) for t in print_list)
+        if disp_graph:
+            task_names = None
+            if filter_tasks or not private:
+                task_names = [task.name for task in print_list]
 
-            template = '{name:<' + str(max_name_len + 3) + '}'
-            if not quiet:
-                template += '{doc}'
-            if status:
-                template = '{status} ' + template
-        template += '\n'
+            graph = self._prepare_graph(tasks, task_names)
+            self._display_graph(graph, template)
+        else:
+            # set template
+            if template is None:
+                max_name_len = 0
+                if print_list:
+                    max_name_len = max(len(t.name) for t in print_list)
 
-        # print list of tasks
-        for task in sorted(print_list):
-            self._print_task(template, task, status, list_deps)
+                template = '{name:<' + str(max_name_len + 3) + '}'
+                if not quiet:
+                    template += '{doc}'
+                if status:
+                    template = '{status} ' + template
+            template += '\n'
+
+            # print list of tasks
+            for task in sorted(print_list):
+                self._print_task(template, task, status, list_deps)
+
         return 0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup
 
 
-install_requires = ['six']
+install_requires = ['six', 'networkx']
 
 
 ########### platform specific stuff #############


### PR DESCRIPTION

![doit_dependencies_graph](https://cloud.githubusercontent.com/assets/501585/6793198/b4214926-d1c1-11e4-8b14-a0c73df77055.png)
FIX #26: Updated ``doit list`` cmd with `--graph` option that opens a matplotlib node-graph window.

Notes:
- It could print a more civilized error if `matplotlib` not installed.
- The `networkx` has been added in the install-requirements; it is a pure-python library for both py2 and py3 so no problems expected from users.
- Tests, CHANGES,and doc-updates if eventually gets accepted.