### PR TITLE
feature: the PythonAction should not wrap any returned TaskFailed or TaskError exceptions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,5 @@
  * Ronan Le Gallic - rolegic <at> gmail <dot> com
  * Simon Conseil - contact <at> saimon <dot> org
  * Kostis Anagnostopoulos - ankostis <at> gmail <dot> com
+ * Randall Schwager - schwager <at> hsph <dot> harvard <dot> edu
+ 

--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,8 @@ Changes
  - read configuration options from INI files
  - fix issue when using unicode strings to specify `minversion` on python 2
  - fix GH-#27 auto command in conjunction with task arguments
-
+ - PythonAction can handle TaskError or TaskFailed exceptions
+ 
 
 0.27.0 (*2015-01-30*)
 ======================

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -68,13 +68,16 @@ as positional and keywords arguments for the callable.
 see `Keyword Arguments <http://docs.python.org/tutorial/controlflow.html#keyword-arguments>`_.
 
 
-The result of the task is given by the returned value of the ``action`` function.
-So it must return a *boolean* value `True`, `None`,
-a dictionary or a string to indicate successful completion of the task.
-Use `False` to indicate task failed.
-If it raises an exception, it will be considered an error.
-If it returns any other type it will also be considered an error
-but this behavior might change in future versions.
+The result of the task is given by the returned value of the
+``action`` function.  It must return `True`, `None`, a dictionary, or
+a string to indicate successful completion of the task.  Returning
+`False` indicates the task generally failed. To provide a more
+detailed description of how the task failed, return an instance of
+:py:class:`TaskFailed` or :py:class:`TaskError`.  If the action raises
+an exception, it will be considered an error.  If the action returns a
+type other than the types already discussed, the action will be
+considered a failure, although this behavior might change in future
+versions.
 
 .. literalinclude:: tutorial/tutorial_02.py
 

--- a/doit/action.py
+++ b/doit/action.py
@@ -390,6 +390,9 @@ class PythonAction(BaseAction):
         elif isinstance(returned_value, dict):
             self.values = returned_value
             self.result = returned_value
+        elif isinstance(returned_value, TaskFailed) \
+             or isinstance(returned_value, TaskError):
+            return returned_value
         else:
             return TaskError("Python Task error: '%s'. It must return:\n"
                              "False for failed task.\n"

--- a/doit/action.py
+++ b/doit/action.py
@@ -390,8 +390,7 @@ class PythonAction(BaseAction):
         elif isinstance(returned_value, dict):
             self.values = returned_value
             self.result = returned_value
-        elif isinstance(returned_value, TaskFailed) \
-             or isinstance(returned_value, TaskError):
+        elif isinstance(returned_value, (TaskFailed, TaskError)):
             return returned_value
         else:
             return TaskError("Python Task error: '%s'. It must return:\n"

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -353,6 +353,21 @@ class TestPythonAction(object):
         got = my_action.execute()
         assert isinstance(got, TaskError)
 
+    def test_error_taskfail(self):
+        # should get the same exception as was returned from the
+        # user's function
+        def error_sample(): return TaskFailed("too bad")
+        ye_olde_action = action.PythonAction(error_sample)
+        ret = ye_olde_action.execute()
+        assert isinstance(ret, TaskFailed)
+        assert str(ret).endswith("too bad\n")
+
+    def test_error_taskerror(self):
+        def error_sample(): return TaskError("so sad")
+        ye_olde_action = action.PythonAction(error_sample)
+        ret = ye_olde_action.execute()
+        assert str(ret).endswith("so sad\n")
+        
     def test_error_exception(self):
         def error_sample(): raise Exception("asdf")
         my_action = action.PythonAction(error_sample)


### PR DESCRIPTION
Sometimes, I have actions that have run time-evaluated conditions.
These actions follow the same strategy: try one thing, if it fails, try something else. 
These are implemented as python actions; an example is here: https://bitbucket.org/biobakery/anadama_workflows/src/ec0cb09417f7ba5ec801b9fa021db7d934c7c015/anadama_workflows/usearch.py?at=master#cl-139

If the python action fails, it's usually because a nested CmdAction returned a TaskError or TaskFailed exception. In that case, the action raises a TaskError with the actual error string masked. The raised TaskError just describes the type of object that was returned; it doesn't tell the user how the action failed.

This feature shows the user how it failed if the PythonAction returns a meaningful exception.

