### PR TITLE
Py3 tutorial

### DIFF
--- a/doc/tutorial/calc_dep.py
+++ b/doc/tutorial/calc_dep.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 DOIT_CONFIG = {'verbosity': 2}
 
 MOD_IMPORTS = {'a': ['b','c'],
@@ -8,10 +9,10 @@ MOD_IMPORTS = {'a': ['b','c'],
 
 
 def print_deps(mod, dependencies):
-    print "%s -> %s" % (mod, dependencies)
+    print("%s -> %s" % (mod, dependencies))
 def task_mod_deps():
     """task that depends on all direct imports"""
-    for mod in MOD_IMPORTS.iterkeys():
+    for mod in MOD_IMPORTS.keys():
         yield {'name': mod,
                'actions': [(print_deps,(mod,))],
                'file_dep': [mod],
@@ -23,7 +24,7 @@ def get_dep(mod):
     return {'file_dep': MOD_IMPORTS[mod]}
 def task_get_dep():
     """get direct dependencies for each module"""
-    for mod in MOD_IMPORTS.iterkeys():
+    for mod in MOD_IMPORTS.keys():
         yield {'name': mod,
                'actions':[(get_dep,[mod])],
                'file_dep': [mod],

--- a/doc/tutorial/clean_mix.py
+++ b/doc/tutorial/clean_mix.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from doit.task import clean_targets
 
 def simple():
-    print "ok"
+    print("ok")
 
 def task_poo():
     return {

--- a/doc/tutorial/cproject.py
+++ b/doc/tutorial/cproject.py
@@ -9,7 +9,7 @@ SOURCE = {
 
 def task_link():
     "create binary program"
-    OBJECTS = ["%s.o" % module for module in SOURCE.iterkeys()]
+    OBJECTS = ["%s.o" % module for module in SOURCE.keys()]
     return {'actions': ['cc -o %(targets)s %(dependencies)s'],
             'file_dep': OBJECTS,
             'targets': ['edit'],
@@ -18,7 +18,7 @@ def task_link():
 
 def task_compile():
     "compile C files"
-    for module, dep in SOURCE.iteritems():
+    for module, dep in SOURCE.items():
         dependencies = dep + ['%s.c' % module]
         yield {'name': module,
                'actions': ["cc -c %s.c" % module],

--- a/doc/tutorial/custom_cmd.py
+++ b/doc/tutorial/custom_cmd.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from doit.cmd_base import Command
 
 
@@ -8,4 +9,4 @@ class Init(Command):
 It will be displayed on `doit help init`"""
 
     def execute(self, opt_values, pos_args):
-        print "TODO: create some files for my project"
+        print("TODO: create some files for my project")

--- a/doc/tutorial/getargs.py
+++ b/doc/tutorial/getargs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 DOIT_CONFIG = {'default_tasks': ['use_cmd', 'use_python']}
 
 def task_compute():
@@ -21,5 +22,5 @@ def task_use_python():
           'verbosity': 2,
           }
 def show_getargs(x, y):
-   print "this is x:%s" % x
-   print "this is y:%s" % y
+   print("this is x:%s" % x)
+   print("this is y:%s" % y)

--- a/doc/tutorial/getargs_dict.py
+++ b/doc/tutorial/getargs_dict.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def task_compute():
    def comp():
        return {'x':5,'y':10, 'z': 20}
@@ -5,7 +6,7 @@ def task_compute():
 
 
 def show_getargs(values):
-   print values
+   print(values)
 
 def task_args_dict():
   return {'actions': [show_getargs],

--- a/doc/tutorial/getargs_group.py
+++ b/doc/tutorial/getargs_group.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def task_compute():
    def comp(x):
        return {'x':x}
@@ -10,8 +11,8 @@ def task_compute():
 
 
 def show_getargs(values):
-    print values
-    assert sum(v['x'] for v in values.itervalues()) == 12
+    print(values)
+    assert sum(v['x'] for v in values.values()) == 12
 
 def task_args_dict():
   return {'actions': [show_getargs],

--- a/doc/tutorial/meta.py
+++ b/doc/tutorial/meta.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 def who(task):
-    print 'my name is', task.name
-    print task.targets
+    print('my name is', task.name)
+    print(task.targets)
 
 def task_x():
     return {

--- a/doc/tutorial/my_dodo.py
+++ b/doc/tutorial/my_dodo.py
@@ -17,7 +17,7 @@ def task_do():
         metadata['name'] = item.__name__
 
         # *I* dont like the names file_dep, targets. So I use 'input', 'output'
-        class Sentinel: pass
+        class Sentinel(object): pass
         input_ = metadata.pop('input', Sentinel)
         output_ = metadata.pop('output', Sentinel)
         args = []

--- a/doc/tutorial/my_tasks.py
+++ b/doc/tutorial/my_tasks.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 def task(*fn, **kwargs):
     # decorator without parameters
@@ -16,16 +17,16 @@ def task(*fn, **kwargs):
 
 @task
 def simple():
-    print "thats all folks"
+    print("thats all folks")
 
 @task(output=['out1.txt', 'out2.txt'])
 def create(to_be_created):
-    print "I should create these files: %s" % " ".join(to_be_created)
+    print("I should create these files: %s" % " ".join(to_be_created))
 
 @task(input=['my_input.txt'], output=['my_output_result.txt'])
 def process(in_, out_):
-    print "processing %s" % in_[0]
-    print "creating %s" % out_[0]
+    print("processing %s" % in_[0])
+    print("creating %s" % out_[0])
 
 
 

--- a/doc/tutorial/parameters.py
+++ b/doc/tutorial/parameters.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 def task_py_params():
     def show_params(param1, param2):
-        print param1
-        print 5 + param2
+        print(param1)
+        print(5 + param2)
     return {'actions':[(show_params,)],
             'params':[{'name':'param1',
                        'short':'p',
@@ -17,7 +18,7 @@ def task_py_params():
 def task_py_params_list():
     def print_a_list(list):
         for item in list:
-            print item
+            print(item)
     return {'actions':[(print_a_list,)],
             'params':[{'name':'list',
                        'short':'l',
@@ -30,7 +31,7 @@ def task_py_params_list():
 
 def task_py_params_choice():
     def print_choice(choice):
-        print choice
+        print(choice)
 
     return {'actions':[(print_choice,)],
             'params':[{'name':'choice',

--- a/doc/tutorial/parameters_inverse.py
+++ b/doc/tutorial/parameters_inverse.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
 def task_with_flag():
     def _task(flag):
-        print "Flag {0}".format("On" if flag else "Off")
+        print("Flag {0}".format("On" if flag else "Off"))
 
     return {
         'params': [{

--- a/doc/tutorial/pos.py
+++ b/doc/tutorial/pos.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 def task_pos_args():
     def show_params(param1, pos):
         print('param1 is: {0}'.format(param1))

--- a/doc/tutorial/sample.py
+++ b/doc/tutorial/sample.py
@@ -1,1 +1,2 @@
-print "hello"
+from __future__ import print_function
+print("hello")

--- a/doc/tutorial/subtasks.py
+++ b/doc/tutorial/subtasks.py
@@ -1,3 +1,4 @@
+from builtins import range
 def task_create_file():
     for i in range(3):
         filename = "file%d.txt" % i

--- a/doc/tutorial/tsetup.py
+++ b/doc/tutorial/tsetup.py
@@ -1,11 +1,12 @@
+from __future__ import print_function
 ### task setup env. good for functional tests!
 DOIT_CONFIG = {'verbosity': 2,
                'default_tasks': ['withenvX', 'withenvY']}
 
 def start(name):
-    print "start %s" % name
+    print("start %s" % name)
 def stop(name):
-    print "stop %s" % name
+    print("stop %s" % name)
 
 def task_setup_sample():
     for name in ('setupX', 'setupY'):


### PR DESCRIPTION
Make tutorial-code py3 compatible.

- Fix print-statement.
- Drop {}.iterkeys().
- STILL left one `iteritems()` (doc/tutorial/cproject.py)