### PR TITLE
Fix the list -s command when result_dep is used.

### DIFF
--- a/doit/cmd_list.py
+++ b/doit/cmd_list.py
@@ -68,7 +68,7 @@ class List(DoitCmdBase):
     STATUS_MAP = {'ignore': 'I', 'up-to-date': 'U', 'run': 'R'}
 
 
-    def _print_task(self, template, task, status, list_deps):
+    def _print_task(self, template, task, status, list_deps, tasks):
         """print a single task"""
         line_data = {'name': task.name, 'doc':task.doc}
         # FIXME group task status is never up-to-date
@@ -77,7 +77,7 @@ class List(DoitCmdBase):
             if self.dep_manager.status_is_ignore(task):
                 task_status = 'ignore'
             else:
-                task_status = self.dep_manager.get_status(task, None)
+                task_status = self.dep_manager.get_status(task, tasks)
             line_data['status'] = self.STATUS_MAP[task_status]
 
         self.outstream.write(template.format(**line_data))
@@ -146,5 +146,5 @@ class List(DoitCmdBase):
 
         # print list of tasks
         for task in sorted(print_list):
-            self._print_task(template, task, status, list_deps)
+            self._print_task(template, task, status, list_deps, tasks)
         return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import py
 import pytest
 
 from doit.dependency import Dependency, backend_map, MD5Checker
-from doit.task import Task
+from doit.task import Task, result_dep
 from doit.cmd_base import TaskLoader
 
 def get_abspath(relativePath):
@@ -138,9 +138,14 @@ def tasks_sample():
         # 4
         Task("g1.b", [""], doc="g1.b doc string", is_subtask=True),
         # 5
-        Task("t3", [""], doc="t3 doc string", task_dep=["t1"])
-        ]
+        Task("t3", [""], doc="t3 doc string", task_dep=["t1"]),
+        # 6
+        Task("t4", [""], doc="t4 doc string"),
+        # 7
+        Task("t5", [""], doc="t5 doc string", uptodate=[result_dep('t4')])
+    ]
     tasks_sample[2].task_dep = ['g1.a', 'g1.b']
+    tasks_sample[6].result = 'yes'
     return tasks_sample
 
 

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -10,6 +10,9 @@ from doit import reporter, runner
 from doit.cmd_run import Run
 from tests.conftest import tasks_sample, CmdFactory
 
+SAMPLE_TASKS_OUTPUT = [".  t1", ".  t2", ".  g1.a", ".  g1.b", ".  t3",
+                       ".  t4", ".  t5"]
+
 
 class TestCmdRun(object):
 
@@ -20,7 +23,7 @@ class TestCmdRun(object):
         result = cmd_run._execute(output)
         assert 0 == result
         got = output.getvalue().split("\n")[:-1]
-        assert [".  t1", ".  t2", ".  g1.a", ".  g1.b", ".  t3"] == got
+        assert SAMPLE_TASKS_OUTPUT == got
 
     def testProcessRunMP(self, dependency1, depfile_name):
         output = StringIO()
@@ -29,7 +32,7 @@ class TestCmdRun(object):
         result = cmd_run._execute(output, num_process=1)
         assert 0 == result
         got = output.getvalue().split("\n")[:-1]
-        assert [".  t1", ".  t2", ".  g1.a", ".  g1.b", ".  t3"] == got
+        assert SAMPLE_TASKS_OUTPUT == got
 
     def testProcessRunMThread(self, dependency1, depfile_name):
         output = StringIO()
@@ -38,7 +41,7 @@ class TestCmdRun(object):
         result = cmd_run._execute(output, num_process=1, par_type='thread')
         assert 0 == result
         got = output.getvalue().split("\n")[:-1]
-        assert [".  t1", ".  t2", ".  g1.a", ".  g1.b", ".  t3"] == got
+        assert SAMPLE_TASKS_OUTPUT == got
 
     def testInvalidParType(self, dependency1, depfile_name):
         output = StringIO()
@@ -59,7 +62,7 @@ class TestCmdRun(object):
         result = cmd_run._execute(output, num_process=1)
         assert 0 == result
         got = output.getvalue().split("\n")[:-1]
-        assert [".  t1", ".  t2", ".  g1.a", ".  g1.b", ".  t3"] == got
+        assert SAMPLE_TASKS_OUTPUT == got
         err = capsys.readouterr()[1]
         assert "WARNING:" in err
         assert "parallel using threads" in err


### PR DESCRIPTION
The tasks dict was not passed to `get_status` when using `doit list --all -s mytask`

```
Traceback (most recent call last):
  File "/home/conseil/lib/doit/doit/doit_cmd.py", line 175, in run
    return command.parse_execute(args)
  File "/home/conseil/lib/doit/doit/cmd_base.py", line 111, in parse_execute
    return self.execute(params, args)
  File "/home/conseil/lib/doit/doit/cmd_base.py", line 352, in execute
    return self._execute(**exec_params)
  File "/home/conseil/lib/doit/doit/cmd_list.py", line 149, in _execute
    self._print_task(template, task, status, list_deps)
  File "/home/conseil/lib/doit/doit/cmd_list.py", line 80, in _print_task
    task_status = self.dep_manager.get_status(task, None)
  File "/home/conseil/lib/doit/doit/dependency.py", line 576, in get_status
    uptodate_result = utd(*args, **utd_kwargs)
  File "/home/conseil/lib/doit/doit/task.py", line 537, in __call__
    dep_task = self.tasks_dict[self.dep_name]
TypeError: 'NoneType' object has no attribute '__getitem__'
```