### PR TITLE
Update `auto` command to use Watchdog

### DIFF
--- a/doit/cmd_auto.py
+++ b/doit/cmd_auto.py
@@ -92,7 +92,7 @@ class Auto(DoitCmdBase):
             class DoitAutoRun(FileModifyWatcher):
                 def handle_event(self, event):
                     # print("FS EVENT -> {}".format(event))
-                    sys.exit(result)
+                    return False
             file_watcher = DoitAutoRun(watch_files)
             # kick start watching process
             file_watcher.loop()

--- a/doit/cmd_auto.py
+++ b/doit/cmd_auto.py
@@ -75,7 +75,7 @@ class Auto(DoitCmdBase):
         arun = Run(task_loader=self.loader)
         params.add_defaults(CmdParse(arun.get_options()).parse([])[0])
         try:
-            result = arun.execute(params, args)
+            arun.execute(params, args)
         # ??? actually tested but coverage doesnt get it...
         except InvalidCommand as err: # pragma: no cover
             sys.stderr.write("ERROR: %s\n" % str(err))

--- a/doit/filewatch.py
+++ b/doit/filewatch.py
@@ -109,15 +109,14 @@ class FileModifyWatcher(object):
         import time
 
         handler = self._handle
-        is_running = True
+        is_running = [True]
 
         class EventHandler(FileSystemEventHandler):
             def on_modified(self, event):
-                nonlocal is_running
                 result = handler(event)
 
                 if result is None or not result:
-                    is_running = False
+                    is_running[0] = False
 
         event_handler = EventHandler()
         observer = Observer()
@@ -127,7 +126,7 @@ class FileModifyWatcher(object):
         observer.start()
 
         try:
-            while is_running:
+            while is_running[0]:
                 time.sleep(1)
         except (SystemExit, KeyboardInterrupt):
             pass

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,8 @@ install_requires = ['six']
 import platform
 platform_system = platform.system()
 
-# auto command dependencies to watch file-system
-if platform_system == "Darwin":
-    install_requires.append('macfsevents')
-elif platform_system == "Linux":
-    install_requires.append('pyinotify')
+# auto command to watch file-system
+install_requires.append('watchdog')
 
 ##################################################
 

--- a/tests/test_filewatch.py
+++ b/tests/test_filewatch.py
@@ -1,7 +1,6 @@
 import os
 import time
 import threading
-from multiprocessing import Process
 
 import pytest
 
@@ -51,7 +50,6 @@ class TestFileWatcher(object):
         fw = FileModifyWatcher((files[0], files[1], stop_file))
         events = []
         should_stop = []
-        started = []
         def handle_event(event):
             events.append(event.src_path)
             if event.src_path.endswith("stop"):

--- a/tests/test_filewatch.py
+++ b/tests/test_filewatch.py
@@ -106,3 +106,41 @@ class TestFileWatcher(object):
 
         assert os.path.abspath(files[0]) == events[0]
         assert os.path.abspath(files[1]) == events[1]
+
+    def testExit(self, restore_cwd, tmpdir):
+        files = ['data/w1.txt', 'data/w2.txt', 'data/w3.txt']
+        tmpdir.mkdir('data')
+        for fname in files:
+            tmpdir.join(fname).open('a').close()
+        os.chdir(tmpdir.strpath)
+
+        fw = FileModifyWatcher((files[0], files[1]))
+        events = []
+        should_stop = []
+        def handle_event(event):
+            events.append(event.src_path)
+            if event.src_path.endswith("stop"):
+                should_stop.append(True)
+                return False
+            return True
+        fw.handle_event = handle_event
+
+        def stopper():
+            time.sleep(.1)
+            try:
+                # Python 2
+                import thread
+                thread.interrupt_main()
+            except ImportError:
+                # Python 3
+                import _thread
+                _thread.interrupt_main()
+
+        # Create a thread that will stop the main thread
+        loop_thread = threading.Thread(target=stopper)
+        loop_thread.daemon = True
+        loop_thread.start()
+
+        # This will block until a SystemExit or
+        # KeyboardInterrupt is raised
+        fw.loop()


### PR DESCRIPTION
The `auto` command now uses [watchdog](https://github.com/gorakhargosh/watchdog) instead of pyfsevents and pyinotify. This provides better platform compatibility (and fixes issue #49), though it only has been tested on Linux and Mac OS. Since I have only tested on these two platforms, I did not update the `supported_platforms` variable in `filewatch.py`.

Watchdog might need to be configured differently. Currently, I have it set to only trigger when files are modified and it does not recursively search subdirectories (lines 71 and 80 of `filewatch.py`). All unit tests pass, but I am not sure what the desired behavior of `doit` is.

The `test_watchfile.py` tests have been changed since no callback can be passed in like previous tests.

