### PR TITLE
Fix pickling on windows so that we can spawn new processes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@
  * Simon Conseil - contact <at> saimon <dot> org
  * Kostis Anagnostopoulos - ankostis <at> gmail <dot> com
  * Randall Schwager - schwager <at> hsph <dot> harvard <dot> edu
+ * Gerlad Storer - https://github.com/gstorer

--- a/doit/control.py
+++ b/doit/control.py
@@ -262,6 +262,11 @@ class ExecNode(object):
         # generator from TaskDispatcher._add_task
         self.generator = None
 
+    def __getstate__(self):
+        pickle_dict = self.__dict__.copy()
+        pickle_dict['generator'] = None
+        return pickle_dict
+        
     def reset_task(self, task, generator):
         """reset task & generator after task is created by its own `loader`"""
         task.loader = DelayedLoaded
@@ -314,6 +319,10 @@ class TaskDispatcher(object):
 
         self.generator = self._dispatcher_generator(selected_tasks)
 
+    def __getstate__(self):
+        pickle_dict = self.__dict__.copy()
+        pickle_dict['generator'] = None
+        return pickle_dict
 
     def _gen_node(self, parent, task_name):
         """return ExecNode for task_name if not created yet"""

--- a/doit/reporter.py
+++ b/doit/reporter.py
@@ -24,7 +24,12 @@ class ConsoleReporter(object):
         self.show_out = options.get('show_out', True)
         self.show_err = options.get('show_err', True)
         self.outstream = outstream
-
+        
+    def __getstate__(self):
+        pickle_dict = self.__dict__.copy()
+        pickle_dict['outstream'] = None
+        return pickle_dict    
+        
     def write(self, text):
         self.outstream.write(text)
 

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -47,7 +47,11 @@ class Runner(object):
         self.final_result = SUCCESS # until something fails
         self._stop_running = False
 
-
+    def __getstate__(self):
+        pickle_dict = self.__dict__.copy()
+        pickle_dict['dep_manager'] = None
+        return pickle_dict 
+        
     def _handle_task_error(self, node, catched_excp):
         """handle all task failures/errors
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -696,11 +696,13 @@ class TestMRunner_parallel_run_tasks(object):
     @pytest.mark.skipif('not runner.MRunner.available()')
     def test_mrunner_picklabe(self, reporter, dep_manager):   
         # Windows requires that the inputs to Process.__init__ are picklable. 
-        # This includes MRunner.
+        # This includes MRunner, TaskDispatcher and ExecNode
         t1 = Task("t1", [(my_print, ["out a"] )] )
         t2 = Task("t2", None, loader=DelayedLoader(static_creator, executed='t1'))
         my_runner = runner.MRunner(dep_manager, reporter)
         pickle.dumps(my_runner)
+        pickle.dumps(TaskDispatcher({'t1':t1, 't2':t2}, [], ['t1', 't2']))
+        pickle.dumps(ExecNode(t1,None))
         
     def test_task_not_picklabe_thread(self, reporter, dep_manager):
         def creator():


### PR DESCRIPTION
Fix for #50. 

Note that I elected to skip pickling all of dep_manager. I figure that its likely extra non-picklable things could be added here in the future.