### PR TITLE
Allowing matches of multiple target regexes.

### DIFF
--- a/doit/cmd_run.py
+++ b/doit/cmd_run.py
@@ -116,6 +116,18 @@ opt_pdb = {
     }
 
 
+# use ".*" as default regex for delayed tasks without explicitly specified regex
+opt_auto_delayed_regex = {
+    'name': 'auto_delayed_regex',
+    'short': '',
+    'long': 'auto-delayed-regex',
+    'type': bool,
+    'default': False,
+    'help':
+"""Uses the default regex ".*" for every delayed task loader for which no regex was explicitly defined"""
+}
+
+
 class Run(DoitCmdBase):
     doc_purpose = "run tasks"
     doc_usage = "[TASK/TARGET...]"
@@ -124,7 +136,8 @@ class Run(DoitCmdBase):
 
     cmd_options = (opt_always, opt_continue, opt_verbosity,
                    opt_reporter, opt_outfile, opt_num_process,
-                   opt_parallel_type, opt_pdb, opt_single)
+                   opt_parallel_type, opt_pdb, opt_single,
+                   opt_auto_delayed_regex)
 
 
     def __init__(self, **kwargs):
@@ -162,7 +175,7 @@ class Run(DoitCmdBase):
     def _execute(self, outfile,
                  verbosity=None, always=False, continue_=False,
                  reporter='console', num_process=0, par_type='process',
-                 single=False):
+                 single=False, auto_delayed_regex=False):
         """
         @param reporter:
                (str) one of provided reporters or ...
@@ -172,7 +185,7 @@ class Run(DoitCmdBase):
         """
         # get tasks to be executed
         # self.control is saved on instance to be used by 'auto' command
-        self.control = TaskControl(self.task_list)
+        self.control = TaskControl(self.task_list, auto_delayed_regex=auto_delayed_regex)
         self.control.process(self.sel_tasks)
 
         if single:

--- a/doit/control.py
+++ b/doit/control.py
@@ -192,17 +192,27 @@ class TaskControl(object):
 
             # check if target matches any regex
             import re
-            for task in self.tasks.values():
+            tasks = []
+            for task in list(self.tasks.values()):
                 if task.loader and task.loader.target_regex:
                     if re.match(task.loader.target_regex, filter_):
-                        loader = task.loader
-                        loader.basename = task.name
-                        name = '_regex_target_' + filter_
-                        self.tasks[name] = Task(name, None,
-                                                loader=loader,
-                                                file_dep=[filter_])
-                        selected_task.append(name)
-                        break
+                        tasks.append(task)
+            if len(tasks) > 0:
+                if len(tasks) == 1:
+                    task = tasks[0]
+                    loader = task.loader
+                    loader.basename = task.name
+                    name = '_regex_target_' + filter_
+                    self.tasks[name] = Task(name, None,
+                                            loader=loader,
+                                            file_dep=[filter_])
+                    selected_task.append(name)
+                else:
+                    name = '_regex_target_' + filter_
+                    self.tasks[name] = Task(name, None,
+                                            task_dep=[task.name for task in tasks],
+                                            file_dep=[filter_])
+                    selected_task.append(name)
             else:
                 # not found
                 msg = ('cmd `run` invalid parameter: "%s".' +

--- a/doit/control.py
+++ b/doit/control.py
@@ -26,9 +26,10 @@ class TaskControl(object):
                           Value: task_name
     """
 
-    def __init__(self, task_list):
+    def __init__(self, task_list, auto_delayed_regex=False):
         self.tasks = {}
         self.targets = {}
+        self.auto_delayed_regex = auto_delayed_regex
 
         # name of task in order to be executed
         # this the order as in the dodo file. the real execution
@@ -194,8 +195,8 @@ class TaskControl(object):
             import re
             tasks = []
             for task in list(self.tasks.values()):
-                if task.loader and task.loader.target_regex:
-                    if re.match(task.loader.target_regex, filter_):
+                if task.loader and (task.loader.target_regex or self.auto_delayed_regex):
+                    if re.match(task.loader.target_regex if task.loader.target_regex else '.*', filter_):
                         tasks.append(task)
             if len(tasks) > 0:
                 if len(tasks) == 1:


### PR DESCRIPTION
If there is more than one regex matching a target, creates a task which has all potential tasks as a dependency and adds it to the list of selected tasks. This allows to specify any target created by a DelayedTask as long as it provides a regex which matches the target name.

(If all delayed task loaders provide `'.*'` as a regex, everything will be made. Not great, but it's not so easy to do better.)