### PR TITLE
Fix #56 -- add AppVeyor Windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.2"
     - "3.3"
     - "3.4"
 #    - 'pypy'  # dbm test fails, remove for now...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+build: false
+branches:
+  only:
+    - master
+    - test
+environment:
+  matrix:
+    - PYTHON: "C:/Python27"
+    - PYTHON: "C:/Python33"
+    - PYTHON: "C:/Python34"
+init:
+  - "ECHO %PYTHON%"
+  - ps: "ls C:/Python*"
+install:
+  #- ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'C:/get-pip.py')
+  #- "%PYTHON%/python.exe C:/get-pip.py"
+  #- "%PYTHON%/Scripts/pip.exe install --upgrade setuptools"
+  - "%PYTHON%/Scripts/pip.exe install ."
+  - "%PYTHON%/Scripts/pip.exe install -r dev_requirements.txt"
+
+test_script:
+  - "set path=%PYTHON%/Scripts;%path%"
+  - "%PYTHON%/python.exe --version"
+  - "%PYTHON%/Scripts/pip.exe --version"
+  - "doit pyflakes"
+  - "py.test"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,11 +4,9 @@ Installing
 
 
 
-* Using `pip <http://pip.openplans.org/>`_ or
-  `easy_install <http://peak.telecommunity.com/DevCenter/EasyInstall>`_::
+* Using `pip <http://pip.pypa.io/>`_::
 
   $ pip install doit
-  $ easy_install doit
 
 * `Download <http://pypi.python.org/pypi/doit>`_ the source and::
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -231,7 +231,7 @@ class TestCmd_print_process_output(object):
         capture = StringIO()
         my_action._print_process_output(Mock(), not_unicode, capture, realtime)
         # get the replacement char
-        expected = '�' if six.PY3 else unicode('�', 'utf-8')
+        expected = '�' if six.PY3 else '�'.decode('utf-8')
         assert expected == capture.getvalue()
 
     def test_non_unicode_string_ok(self):
@@ -242,7 +242,7 @@ class TestCmd_print_process_output(object):
         capture = StringIO()
         my_action._print_process_output(Mock(), not_unicode, capture, realtime)
         # get the correct char from latin-1 encoding
-        expected = '©' if six.PY3 else unicode('©', 'utf-8')
+        expected = '©' if six.PY3 else '©'.decode('utf-8')
         assert expected == capture.getvalue()
 
 

--- a/tests/test_cmd_auto.py
+++ b/tests/test_cmd_auto.py
@@ -1,4 +1,6 @@
 import time
+import sys
+import pytest
 from multiprocessing import Process
 
 from doit.cmdparse import DefaultUpdate
@@ -6,6 +8,8 @@ from doit.task import Task
 from doit.cmd_base import TaskLoader
 from doit import cmd_auto
 from .conftest import CmdFactory
+
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='auto is linux/osx only')
 
 
 class TestFindFileDeps(object):

--- a/tests/test_cmd_info.py
+++ b/tests/test_cmd_info.py
@@ -71,7 +71,7 @@ class TestCmdInfo(object):
         }
 
         got = Info.get_reasons(reasons).splitlines()
-        print repr(got)
+        print(repr(got))
         assert len(got) == 7
         assert got[0] == ' * The task has no dependencies.'
         assert got[1] == ' * The following uptodate objects evaluate to false:'


### PR DESCRIPTION
This adds the AppVeyor config file (#56), and a few bonus fixes.

**Caveats:**
* The tests do not pass yet. I disabled `cmd_auto` testing on Windows (it hangs forever and is not supported anyway); there are also pickling errors.
* Python 3.2 is not supported on AppVeyor. Since you don’t have it in your trove classifiers, and most of the Python world dropped support for Python 3.2, I disabled it in Travis too.

**Setup:**
1. merge this
2. sign into AppVeyor with GitHub
3. create new project for `doit`
4. press “New build”
5. Go to settings, configure *Branches to build* manually (I tried doing it via the `appveyor.yml` file but it did not pick it up for me when I tested it)
6. You might also need to configure e-mail notifications in your profile.

(I also updated your install doc to drop `easy_install`, which is discouraged nowadays.)