### PR TITLE
Handle python3 callables with keyword only args and annotations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@
  * Simon Conseil - contact <at> saimon <dot> org
  * Kostis Anagnostopoulos - ankostis <at> gmail <dot> com
  * Randall Schwager - schwager <at> hsph <dot> harvard <dot> edu
+ * Pavel Platto - hinidu <at> gmail <dot> com

--- a/doit/action.py
+++ b/doit/action.py
@@ -40,10 +40,19 @@ class BaseAction(object):
         if not task:
             return kwargs
 
-        try:
-            argspec = inspect.getargspec(func)
-        except TypeError: # a callable object, not a function
-            argspec = inspect.getargspec(func.__call__)
+        if six.PY2:
+            try:
+                argspec = inspect.getargspec(func)
+            except TypeError: # a callable object, not a function
+                argspec = inspect.getargspec(func.__call__)
+            func_has_kwargs = argspec.keywords is not None
+        else:
+            try:
+                argspec = inspect.getfullargspec(func)
+            except TypeError: # a callable object, not a function
+                argspec = inspect.getfullargspec(func.__call__)
+            func_has_kwargs = argspec.varkw is not None
+
         # use task meta information as extra_args
         meta_args = {
             'task': task,
@@ -79,7 +88,7 @@ class BaseAction(object):
                     kwargs[key] = extra_args[key]
 
             # if function has **kwargs include extra_arg on it
-            elif argspec.keywords and key not in kwargs:
+            elif func_has_kwargs and key not in kwargs:
                 kwargs[key] = extra_args[key]
         return kwargs
 


### PR DESCRIPTION
Hi, @schettino72!
I've added the usage of `inspect.getfullargs` in python3 so it should handle python callables with keyword only arguments and annotations.
Though I have one issue: I'm pretty new to the python and I don't know any way to hide the code from interpreter if python2 is used, so new tests generate syntax errors with python2 because keyword only arguments were syntactically incorrect before python3. Do you have any suggestions which I could use to solve this issue?
Original issue: #74
PS. Sorry for submitting the patch later than I was promising (life always gets in the way).