### PR TITLE
Please make the completion output deterministic

### DIFF
--- a/doit/cmd_completion.py
+++ b/doit/cmd_completion.py
@@ -101,7 +101,7 @@ class TabCompletion(DoitCmdBase):
             self.task_list, _ = self.loader.load_tasks(
                 self, opt_values, pos_args)
             tmpl_vars['pt_tasks'] = '"{0}"'.format(
-                ' '.join(t.name for t in self.task_list if not t.is_subtask))
+                ' '.join(sorted(t.name for t in self.task_list if not t.is_subtask)))
         else:
             tmpl_list_cmd = "$({0} list {1} --quiet 2>/dev/null)"
             tmpl_vars['pt_tasks'] = tmpl_list_cmd.format(pt_bin_name,
@@ -196,7 +196,7 @@ class TabCompletion(DoitCmdBase):
             for task in self.task_list:
                 if not task.is_subtask:
                     lines.append("'{0}: {1}'".format(task.name, task.doc))
-            template_vars['pt_tasks'] = '(\n{0}\n)'.format('\n'.join(lines))
+            template_vars['pt_tasks'] = '(\n{0}\n)'.format('\n'.join(sorted(lines)))
         else:
             tmp_tasks = Template(
                 '''("${(f)$($pt_bin_name list --template '{name}: {doc}')}")''')


### PR DESCRIPTION
While working on the "reproducible builds" effort [1], I noticed that doit
generates completion that is non-determistic due to the arbitrary nature
of Python dict ordering.

This patch removes this randomness by sorting prior to output. Once
applied, packages using doit (eg. nikola, etc.) can be built reproducibly
in our toolchain.

 [1]: https://wiki.debian.org/ReproducibleBuilds

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>