### PR TITLE
Add tests for Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,69 @@
-language: python
-python:
-    - "2.7"
-    - "3.3"
-    - "3.4"
-#    - "3.5.0b3" # requires py.test 2.7.3 unreleased at this time
-    - "pypy"
-    - "pypy3"
-
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - strace
-
-install:
-  - pip install .
-  - pip install -r dev_requirements.txt python-coveralls
+language: python
 
 branches:
   only:
     - master
     - test
 
+matrix:
+  include:
+    - python: 2.7
+      addons:
+        apt:
+          packages:
+            - strace
+    - python: 3.3
+      addons:
+        apt:
+          packages:
+            - strace
+    - python: 3.4
+      addons:
+        apt:
+          packages:
+            - strace
+    - python: pypy
+      addons:
+        apt:
+          packages:
+            - strace
+    - python: pypy3
+      addons:
+        apt:
+          packages:
+            - strace
+    - language: generic
+      os: osx
+      env: PYTHON_VERSION=py27
+    - language: generic
+      os: osx
+      env: PYTHON_VERSION=py33
+    - language: generic
+      os: osx
+      env: PYTHON_VERSION=py34
+    - language: generic
+      os: osx
+      env: PYTHON_VERSION=pypy
+    - language: generic
+      os: osx
+      env: PYTHON_VERSION=pypy3
+
+  allow_failures:
+    - env: PYTHON_VERSION=pypy3
+
+install:
+  - ./.travis/install.sh
 
 script:
-   - doit pyflakes
-   - py.test --ignore-flaky
-   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then doit coverage; fi
+  - ./.travis/run.sh
+
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
 
 notifications:
-    email:
-        on_success: change
-        on_failure: change
+  email:
+    on_success: change
+    on_failure: change
+

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    brew update || brew update
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    case "${PYTHON_VERSION}" in
+        py27)
+            brew outdated pyenv || brew upgrade pyenv
+            pyenv install 2.7.10
+            pyenv global 2.7.10
+            ;;
+        py33)
+            brew outdated pyenv || brew upgrade pyenv
+            pyenv install 3.3.6
+            pyenv global 3.3.6
+            ;;
+        py34)
+            brew outdated pyenv || brew upgrade pyenv
+            pyenv install 3.4.2
+            pyenv global 3.4.2
+            ;;
+        pypy)
+            brew outdated pyenv || brew upgrade pyenv
+            pyenv install pypy-2.6.1
+            pyenv global pypy-2.6.1
+            ;;
+        pypy3)
+            brew outdated pyenv || brew upgrade pyenv
+            pyenv install pypy3-2.4.0
+            pyenv global pypy3-2.4.0
+            ;;
+    esac
+    pyenv rehash
+    python -m pip install --user virtualenv
+
+    python -m virtualenv ~/.venv
+    source ~/.venv/bin/activate
+
+    sudo pip install .
+    sudo pip install -r dev_requirements.txt python-coveralls
+else
+    pip install .
+    pip install -r dev_requirements.txt python-coveralls
+fi
+
+

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+    eval "$(pyenv init -)"
+    source ~/.venv/bin/activate
+fi
+
+python --version
+doit pyflakes
+py.test --ignore-flaky
+
+if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
+    doit coverage
+fi


### PR DESCRIPTION
I added the ability to test Mac OS X on Travis CI. The solution is kind of heavy handed and involves changing a lot of `.travis.yml` and adding some helper scripts, but it works and it seems to be the only way to test Python projects on OS X. I used [another repository](https://github.com/pyca/cryptography/blob/master/.travis.yml) for inspiration on how to format `.travis.yml` and write the scripts to allow for testing on OS X. 

Here is a Travis CI build on my fork testing both Linux and OS X: https://travis-ci.org/philipbl/doit/builds/78691539

Currently, the OS X tests get stuck (as described in #101) and eventually time out. One of the tests (pypy3 on OS X) fails for other reasons, so I made that test optional.