### PR TITLE
Add support for Path from pathlib.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Changes
  - fix GH-#99: positional argument on tasks not specified from cmd-line
  - fix GH-#97: `list` command does not display task-doc for `DelayedTask`
                 when `creates` is specified
+ - GH-#114: `file_dep`, `targets` and `CmdAction` support pathlib.
 
 
 0.29.0 (*2015-08-16*)

--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -133,7 +133,9 @@ python code from the `dodo` file. Let's take a look at another example:
   so in this example the line `msg = 3 * "hi! "` will always be executed.
 
 
-If `action` is a list of strings, by default it will be executed **without the shell** (Popen argument shell=False).
+If `action` is a list of strings and instances of any Path class from
+`pathlib <https://docs.python.org/3/library/pathlib.html>`_, by default it will
+be executed **without the shell** (Popen argument shell=False).
 
 .. literalinclude:: tutorial/cmd_actions_list.py
 
@@ -330,6 +332,9 @@ You don't need to compile anything but you probably want to apply a lint-like
 tool (i.e. `pyflakes <http://pypi.python.org/pypi/pyflakes>`_) to your
 source code files. You can define the source code as a dependency to the task.
 
+Every depenendency in file_dep list should be a string or an instance of any
+Path class from `pathlib <https://docs.python.org/3/library/pathlib.html>`_.
+
 
 .. literalinclude:: tutorial/checker.py
 
@@ -351,7 +356,9 @@ targets
 
 Targets can be any file path (a file or folder). If a target doesn't exist
 the task will be executed. There is no limitation on the number of targets
-a task may define. Two different tasks can not have the same target.
+a task may define. Two different tasks can not have the same target. Target
+can be specified as a string or as an instance of any Path class from
+`pathlib <https://docs.python.org/3/library/pathlib.html>`_.
 
 Lets take the compilation example again.
 

--- a/doc/tutorial/checker.py
+++ b/doc/tutorial/checker.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+
 def task_checker():
     return {'actions': ["pyflakes sample.py"],
             'file_dep': ["sample.py"]}
+
+def task_checker_pathlib():
+    sample_path = Path("sample.py")
+    return {'actions': [["pyflakes", sample_path]],
+            'file_dep': [sample_path]}

--- a/doit/action.py
+++ b/doit/action.py
@@ -214,15 +214,17 @@ class CmdAction(BaseAction):
 
 
     def expand_action(self):
-        """expand action string using task meta informations
-        @returns (string) - expanded string after substitution
+        """Expand action using task meta informations if action is a string.
+        Convert `Path` elements to `str` if action is a list.
+        @returns: string -> expanded string if action is a string
+                  list - string -> expanded list of command elements
         """
         if not self.task:
             return self.action
 
         # cant expand keywords if action is a list of strings
         if isinstance(self.action, list):
-            return self.action
+            return [str(x) for x in self.action]
 
         subs_dict = {'targets' : " ".join(self.task.targets),
                      'dependencies': " ".join(self.task.file_dep)}

--- a/doit/action.py
+++ b/doit/action.py
@@ -4,6 +4,7 @@
 import subprocess, sys
 from io import StringIO
 import inspect
+from pathlib import PurePath
 from threading import Thread
 
 from .exceptions import InvalidTask, TaskFailed, TaskError
@@ -224,7 +225,18 @@ class CmdAction(BaseAction):
 
         # cant expand keywords if action is a list of strings
         if isinstance(self.action, list):
-            return [str(x) for x in self.action]
+            action = []
+            for element in self.action:
+                if isinstance(element, str):
+                    action.append(element)
+                elif isinstance(element, PurePath):
+                    action.append(str(element))
+                else:
+                    msg = ("%s. CmdAction element must be a str " +
+                           "or Path from pathlib. Got '%r' (%s)")
+                    raise InvalidTask(
+                        msg % (self.task.name, element, type(element)))
+            return action
 
         subs_dict = {'targets' : " ".join(self.task.targets),
                      'dependencies': " ".join(self.task.file_dep)}

--- a/doit/task.py
+++ b/doit/task.py
@@ -176,7 +176,7 @@ class Task(object):
         self.value_savers = []
         self.uptodate = self._init_uptodate(uptodate)
 
-        self.targets = targets
+        self.targets = [str(target) for target in targets]
         self.is_subtask = is_subtask
         self.has_subtask = has_subtask
         self.result = None

--- a/doit/task.py
+++ b/doit/task.py
@@ -176,7 +176,7 @@ class Task(object):
         self.value_savers = []
         self.uptodate = self._init_uptodate(uptodate)
 
-        self.targets = [str(target) for target in targets]
+        self.targets = self._init_targets(targets)
         self.is_subtask = is_subtask
         self.has_subtask = has_subtask
         self.result = None
@@ -215,6 +215,21 @@ class Task(object):
         self.calc_dep = set()
         if calc_dep:
             self._expand_calc_dep(calc_dep)
+
+
+    def _init_targets(self, items):
+        """convert valid targets to `str`"""
+        targets = []
+        for target in items:
+            if isinstance(target, str):
+                targets.append(target)
+            elif isinstance(target, PurePath):
+                targets.append(str(target))
+            else:
+                msg = ("%s. target must be a str or Path from pathlib. " +
+                       "Got '%r' (%s)")
+                raise InvalidTask(msg % (self.name, target, type(target)))
+        return targets
 
 
     def _init_uptodate(self, items):

--- a/doit/task.py
+++ b/doit/task.py
@@ -7,6 +7,7 @@ import sys
 import inspect
 from collections import OrderedDict
 from functools import partial
+from pathlib import PurePath
 
 from .cmdparse import CmdOption, TaskParse
 from .exceptions import CatchedException, InvalidTask
@@ -247,10 +248,14 @@ class Task(object):
     def _expand_file_dep(self, file_dep):
         """put input into file_dep"""
         for dep in file_dep:
-            if not isinstance(dep, str):
-                raise InvalidTask("%s. file_dep must be a str got '%r' (%s)" %
-                                  (self.name, dep, type(dep)))
-            self.file_dep.add(dep)
+            if isinstance(dep, str):
+                self.file_dep.add(dep)
+            elif isinstance(dep, PurePath):
+                self.file_dep.add(str(dep))
+            else:
+                msg = ("%s. file_dep must be a str or Path from pathlib. " +
+                       "Got '%r' (%s)")
+                raise InvalidTask(msg % (self.name, dep, type(dep)))
 
 
     def _expand_task_dep(self, task_dep):

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,15 @@ elif platform_system == "Linux":
 ##################################################
 
 
+######### python version specific stuff ##########
+
+# pathlib is the part of the Python standard library since 3.4 version.
+if sys.version_info < (3, 4):
+    install_requires.append('pathlib2')
+
+##################################################
+
+
 long_description = """
 `doit` is a task management & automation tool
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -4,6 +4,7 @@ import tempfile
 import textwrap
 import locale
 locale # quiet pyflakes
+from pathlib import PurePath, Path
 
 from io import StringIO, BytesIO
 import pytest
@@ -221,6 +222,12 @@ class TestCmdExpandAction(object):
         task = FakeTask([],[],[], {})
         my_action = action.CmdAction(cmd, task)
         assert cmd == my_action.expand_action()
+
+    def test_list_can_contain_path(self):
+        cmd = ["python", PurePath(TEST_PATH), Path("myecho.py")]
+        task = FakeTask([], [], [], {})
+        my_action = action.CmdAction(cmd, task)
+        assert ["python", TEST_PATH, "myecho.py"] == my_action.expand_action()
 
 
 class TestCmd_print_process_output(object):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -229,6 +229,12 @@ class TestCmdExpandAction(object):
         my_action = action.CmdAction(cmd, task)
         assert ["python", TEST_PATH, "myecho.py"] == my_action.expand_action()
 
+    def test_list_should_contain_strings_or_paths(self):
+        cmd = ["python", PurePath(TEST_PATH), 42, Path("myecho.py")]
+        task = FakeTask([], [], [], {})
+        my_action = action.CmdAction(cmd, task)
+        assert pytest.raises(action.InvalidTask, my_action.expand_action)
+
 
 class TestCmd_print_process_output(object):
     def test_non_unicode_string_error_strict(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -192,6 +192,13 @@ class TestTaskDeps(object):
         assert [(None, None, None), (True, None, None)] == my_task.uptodate
 
 
+class TestTaskPathlibSupport(object):
+
+    def test_targets_can_be_path(self):
+        my_task = task.Task("Task X", ["taskcmd"],
+                            targets=["123", Path("456"), PurePath("789")])
+        assert ["123", "456", "789"] == my_task.targets
+
 
 class TestTask_Loader(object):
     def test_delayed_after_execution(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,6 +1,7 @@
 import os, shutil
 import tempfile
 from io import StringIO
+from pathlib import Path, PurePath
 
 import pytest
 
@@ -150,9 +151,14 @@ class TestTaskExpandFileDep(object):
         my_task = task.Task("Task X", ["taskcmd"], file_dep=["123","456"])
         assert set(["123","456"]) == my_task.file_dep
 
-    def test_file_dep_must_be_string(self):
+    def test_file_dep_path(self):
+        my_task = task.Task("Task X", ["taskcmd"],
+                            file_dep=["123", Path("456"), PurePath("789")])
+        assert {"123", "456", "789"} == my_task.file_dep
+
+    def test_file_dep_str(self):
         pytest.raises(task.InvalidTask, task.Task, "Task X", ["taskcmd"],
-                       file_dep=[['aaaa']])
+                      file_dep=[['aaaa']])
 
     def test_file_dep_unicode(self):
         unicode_name = "中文"

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -192,12 +192,15 @@ class TestTaskDeps(object):
         assert [(None, None, None), (True, None, None)] == my_task.uptodate
 
 
-class TestTaskPathlibSupport(object):
-
+class TestTaskTargets(object):
     def test_targets_can_be_path(self):
         my_task = task.Task("Task X", ["taskcmd"],
                             targets=["123", Path("456"), PurePath("789")])
         assert ["123", "456", "789"] == my_task.targets
+
+    def test_targets_should_be_string_or_path(self):
+        assert pytest.raises(task.InvalidTask, task.Task, "Task X", ["taskcmd"],
+                             targets=["123", Path("456"), 789])
 
 
 class TestTask_Loader(object):


### PR DESCRIPTION
Adding support for `Path` in `file_dep` is quite easy. But clearly this is only the part of the problem: if someone (like me) uses `Path` then he want to use them all other the place. It would be quite strange to pass them to `file_dep` as is but convert to `str` before passing in `targets` for example. I think at least `targets` should support them too and perhaps it would be not very bad idea to support them in `CmdAction`.
@schettino72 what do you think about it?