### PR TITLE
Skip strace tests on windows and cygwin.

### DIFF
--- a/tests/test_cmd_strace.py
+++ b/tests/test_cmd_strace.py
@@ -10,7 +10,8 @@ from doit.task import Task
 from doit.cmd_strace import Strace
 from .conftest import CmdFactory
 
-@pytest.mark.skipif("os.system('strace -V') != 0")
+@pytest.mark.skipif(
+    "os.system('strace -V') != 0 or sys.platform in ['win32', 'cygwin']")
 class TestCmdStrace(object):
 
     def test_dep(self, dependency1, depfile_name):


### PR DESCRIPTION
AppVeyor now provides `strace` from `cygwin`. This fact was discovered in https://github.com/pydoit/doit/pull/114#issuecomment-158134093. This PR provides a quick fix for that problem.
Actually I didn't use `doit strace` command, maybe later someone who finds it useful will fix it on Windows :-)