### PR TITLE
Prevent PythonAction from modifying task attributes by passing copies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,7 @@
  * Michael Gliwinski - https://launchpad.net/~tzeentch-gm
  * Vadim Fint - mocksoul <at> gmail <dot> com
  * Thomas Kluyver - https://bitbucket.org/takluyver
- * rbeagrie - https://bitbucket.org/rbeagrie
+ * Rob Beagrie - http://rob.beagrie.com
  * Miguel Angel Garcia - http://magmax.org
  * Roland Puntaier - roland <dot> puntaier <at> gmail <dot> com
  * Vincent Férotin - vincent <dot> ferotin <at> gmail <dot> com

--- a/dodo.py
+++ b/dodo.py
@@ -10,8 +10,6 @@ from doitpy import docs
 from doitpy.package import Package
 
 
-from doit.tools import create_folder
-
 DOIT_CONFIG = {
     'minversion': '0.24.0',
     'default_tasks': ['pyflakes', 'ut'],

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -701,6 +701,21 @@ class TestPythonActionPrepareKwargsMeta(object):
         my_action.execute()
         assert [1, (2, 3), 4, 5] == got, repr(got)
 
+    def test_action_modifies_task_attributes(self, task_depchanged):
+        def py_callable(targets, dependencies, changed, task):
+            targets.pop()
+            dependencies.pop()
+            changed.pop()
+        my_action = action.PythonAction(py_callable, task=task_depchanged)
+        my_action.execute()
+
+        assert task_depchanged.file_dep == ['dependencies']
+
+        assert task_depchanged.targets == ['targets']
+
+        assert task_depchanged.dep_changed == ['changed']
+
+
 ##############
 
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -703,17 +703,17 @@ class TestPythonActionPrepareKwargsMeta(object):
 
     def test_action_modifies_task_attributes(self, task_depchanged):
         def py_callable(targets, dependencies, changed, task):
-            targets.pop()
-            dependencies.pop()
-            changed.pop()
+            targets.append('new_target')
+            dependencies.append('new_dependency')
+            changed.append('new_changed')
         my_action = action.PythonAction(py_callable, task=task_depchanged)
         my_action.execute()
 
-        assert task_depchanged.file_dep == ['dependencies']
+        assert task_depchanged.file_dep == ['dependencies', 'new_dependency']
 
-        assert task_depchanged.targets == ['targets']
+        assert task_depchanged.targets == ['targets', 'new_target']
 
-        assert task_depchanged.dep_changed == ['changed']
+        assert task_depchanged.dep_changed == ['changed', 'new_changed']
 
 
 ##############


### PR DESCRIPTION
Currently, if a PythonAction calls pop() or otherwise modifies dependencies, targets or changed, these changes are reflected in the task itself. This leads to the dependency or target in question not being added to the doit database properly after execution has finished.