### PR TITLE
Fix race condition in doit.tools.create_folder

### DIFF
--- a/doit/tools.py
+++ b/doit/tools.py
@@ -15,8 +15,7 @@ result_dep # pyflakes
 # action
 def create_folder(dir_path):
     """create a folder in the given path if it doesnt exist yet."""
-    if not (os.path.exists(dir_path) and os.path.isdir(dir_path)):
-        os.makedirs(dir_path)
+    os.makedirs(dir_path, exist_ok=True)
 
 
 # title


### PR DESCRIPTION
Hi again!
While making possible to run build of my project concurrently with `-n NUMBER` option I discovered that `create_folder` has a race condition: if many tasks try to create the same folder then it is possible that between checking directory existence and actual creation of the directory in the next line another task will create that directory.
[Since python 3.2](https://docs.python.org/3.4/library/os.html#os.makedirs) `os.makedirs` has nice `exist_ok` argument that will do the same thing but [without such problems](https://hg.python.org/cpython/file/tip/Lib/os.py#l233).