### PR TITLE
Fix auto command on OS X

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@
  * Randall Schwager - schwager <at> hsph <dot> harvard <dot> edu
  * Pavel Platto - hinidu <at> gmail <dot> com
  * Gerlad Storer - https://github.com/gstorer
+ * Simon Mutch - https://github.com/smutch

--- a/doit/filewatch.py
+++ b/doit/filewatch.py
@@ -69,14 +69,7 @@ class FileModifyWatcher(object):
             observer.schedule(stream)
 
         observer.daemon = True
-        observer.start()
-        try:
-            # hack to keep main thread running...
-            import time
-            while True:
-                time.sleep(99999)
-        except (SystemExit, KeyboardInterrupt):
-            pass
+        observer.run()
 
 
     def _loop_linux(self, loop_callback):


### PR DESCRIPTION
This PR starts the fsevents observer on the main thread, allowing the auto command to pickup file changes and run the appropriate tasks.  This may address #49 (and possibly #101) by fixing the current implementation without moving to using Watchdog.

The filewatcher test fails on OS X both before and after this patch, but testing the auto command manually after applying the patch seems to show that the auto command works.  I am unaware if there are any unintended consequences of running the observer on the main thread though as I have no previous experience with fsevents.