### PR TITLE
Clarify order of tasks shown by doit list command

### DIFF
--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -34,13 +34,14 @@ list
 ------
 
 *list* is used to show all tasks available in a *dodo* file.
+Tasks are listed in alphabetical order, not by order of execution.
 
 .. code-block:: console
 
    $ doit list
-   link : create binary program
    compile : compile C files
    install : install executable (TODO)
+   link : create binary program
 
 
 By default task name and description are listed. The task description is taken


### PR DESCRIPTION
The doit list command shows tasks in alphabetical order, but the
documentation gives the impression that tasks are shown in some other
order. This can cause confusion for users expecting tasks to appear in
order of execution.