### PR TITLE
Fix KeyError on doit list --status when missing file dependency

### DIFF
--- a/doit/cmd_list.py
+++ b/doit/cmd_list.py
@@ -65,7 +65,7 @@ class List(DoitCmdBase):
                    opt_list_private, opt_list_dependencies, opt_template)
 
 
-    STATUS_MAP = {'ignore': 'I', 'up-to-date': 'U', 'run': 'R'}
+    STATUS_MAP = {'ignore': 'I', 'up-to-date': 'U', 'run': 'R', 'error': 'E'}
 
 
     def _print_task(self, template, task, status, list_deps, tasks):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,14 @@ def tasks_sample():
     return tasks_sample
 
 
+def tasks_bad_sample():
+    """Create list of tasks that cause errors."""
+    bad_sample = [
+        Task("e1", [""], doc='e4 bad file dep', file_dep=['xxxx'])
+    ]
+    return bad_sample
+
+
 def CmdFactory(cls, outstream=None, task_loader=None, dep_file=None,
                backend=None, task_list=None, sel_tasks=None,
                dep_manager=None, config=None, cmds=None):

--- a/tests/test_cmd_list.py
+++ b/tests/test_cmd_list.py
@@ -6,7 +6,7 @@ from doit.exceptions import InvalidCommand
 from doit.task import Task
 from doit.tools import result_dep
 from doit.cmd_list import List
-from tests.conftest import tasks_sample, CmdFactory
+from tests.conftest import tasks_sample, tasks_bad_sample, CmdFactory
 
 
 class TestCmdList(object):
@@ -98,6 +98,20 @@ class TestCmdList(object):
         assert 'R g1' in got
         assert 'I t1' in got
         assert 'U t2' in got
+
+
+    def testErrorStatus(self, dependency1, depfile):
+        """Check that problematic tasks show an 'E' as status."""
+        task_list = tasks_bad_sample()
+
+        output = StringIO()
+        cmd_list = CmdFactory(List, outstream=output, dep_file=depfile.name,
+                        backend='dbm', task_list=task_list)
+        cmd_list._execute(status=True)
+        for line in output.getvalue().split('\n'):
+            if line:
+                assert line.strip().startswith('E ')
+
 
     def testStatus_result_dep_bug_gh44(self, dependency1, depfile):
         # make sure task dict is passed when checking up-to-date


### PR DESCRIPTION
Tasks missing a file dependency will cause a `KeyError` on `doit list --status` because `List.STATUS_MAP` lacks an `'error'` key.

This pull requests resolves the issue by showing `'E'` next to the task name.

Example of a problematic `dodo.py` that causes a `KeyError` on `doit list --status` before this fix:

``` python
def task_a():
    """Task A"""
    return {
        'actions': ['echo "hello" > a.txt'],
        'file_dep': ['b.txt']  # assume b.txt does not exist
    }
```
