### PR TITLE
Conditional SQLite import

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@
  * Pavel Platto - hinidu <at> gmail <dot> com
  * Gerlad Storer - https://github.com/gstorer
  * Simon Mutch - https://github.com/smutch
+ * Michael Milton - https://github.com/tmiguelt

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -17,7 +17,6 @@ import dbm as ddbm
 #       >>> anydbm._defaultmod
 
 import json
-import sqlite3
 
 
 class DatabaseException(Exception):
@@ -241,6 +240,9 @@ class SqliteDB(object):
     @staticmethod
     def _sqlite3(name):
         """Open/create a sqlite3 DB file"""
+
+        # Import sqlite here so it's only imported when required
+        import sqlite3
         def dict_factory(cursor, row):
             """convert row to dict"""
             data = {}

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -1,5 +1,7 @@
 import os
 import time
+import sys
+import tempfile
 
 import pytest
 
@@ -28,6 +30,15 @@ def test_md5():
     expected = "45d1503cb985898ab5bd8e58973007dd"
     assert expected == get_file_md5(filePath)
 
+
+def test_sqlite_import():
+    """
+    Checks that SQLite module is not imported until the SQLite class is instantiated
+    """
+    with tempfile.NamedTemporaryFile() as temp:
+        assert 'sqlite3' not in sys.modules
+        SqliteDB(temp.name)
+        assert 'sqlite3' in sys.modules
 
 ####
 # dependencies are files only (not other tasks).

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -2,6 +2,7 @@ import os
 import time
 import sys
 import tempfile
+import uuid
 
 import pytest
 
@@ -35,10 +36,13 @@ def test_sqlite_import():
     """
     Checks that SQLite module is not imported until the SQLite class is instantiated
     """
-    with tempfile.NamedTemporaryFile() as temp:
-        assert 'sqlite3' not in sys.modules
-        SqliteDB(temp.name)
-        assert 'sqlite3' in sys.modules
+    filename = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
+
+    assert 'sqlite3' not in sys.modules
+    SqliteDB(filename)
+    assert 'sqlite3' in sys.modules
+
+    os.remove(filename)
 
 ####
 # dependencies are files only (not other tasks).


### PR DESCRIPTION
Only imports the SQLite module as required, as documented in [doit issue 153](https://github.com/pydoit/doit/issues/153).

This is useful in cases where python has been compiled without sqlite support but users want to use a different backend (e.g. json)

Includes a small unit test for this requirement.