### PR TITLE
Fix #161 -- use extras_require to specify per-platform/per-Python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     packages:
       - strace
 
+before_install:
+  - pip install -U pip setuptools
+
 install:
   - pip install .
   - pip install -r dev_requirements.txt python-coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,8 @@ install:
   # works with Python 2.7.
   # See: https://github.com/pytest-dev/pytest/issues/749
   #      https://bitbucket.org/pytest-dev/pytest/issues/749/
-  - "%PYTHON%/Scripts/pip.exe install pytest --no-use-wheel"
+  - "%PYTHON%/python.exe -m pip install -U pip"
+  - "%PYTHON%/Scripts/pip.exe install -U setuptools pytest --no-binary all"
 
   - "%PYTHON%/Scripts/pip.exe install ."
   - "%PYTHON%/Scripts/pip.exe install -r dev_requirements.txt"

--- a/setup.py
+++ b/setup.py
@@ -15,29 +15,6 @@ if sys.version_info[0] < 3:
 
 ########################################################
 
-
-########### platform specific stuff #############
-import platform
-platform_system = platform.system()
-
-# auto command dependencies to watch file-system
-if platform_system == "Darwin":
-    install_requires.append('macfsevents')
-elif platform_system == "Linux":
-    install_requires.append('pyinotify')
-
-##################################################
-
-
-######### python version specific stuff ##########
-
-# pathlib is the part of the Python standard library since 3.4 version.
-if sys.version_info < (3, 4):
-    install_requires.append('pathlib2')
-
-##################################################
-
-
 long_description = """
 `doit` is a task management & automation tool
 
@@ -87,6 +64,11 @@ setup(name = 'doit',
 
       packages = ['doit'],
       install_requires = install_requires,
+      extras_require={
+          ':python_version <= "3.3"': ['pathlib2'],
+          ':sys.platform == "darwin"': ['macfsevents'],
+          ':sys.platform == "linux"': ['pyinotify'],
+      },
       long_description = long_description,
       entry_points = {
           'console_scripts': [


### PR DESCRIPTION
This fixes #161. pip understands `extras_require` and uses them properly.