### PR TITLE
Fix passing environment variables to CmdAction

### DIFF
--- a/doit/action.py
+++ b/doit/action.py
@@ -189,9 +189,14 @@ class CmdAction(BaseAction):
                 "CmdAction Error creating command string", exc)
 
         # set environ to change output buffering
+        subprocess_pkwargs = self.pkwargs.copy()
         env = None
+        if 'env' in subprocess_pkwargs:
+            env = subprocess_pkwargs['env']
+            del subprocess_pkwargs['env']
         if self.buffering:
-            env = os.environ.copy()
+            if not env:
+                env = os.environ.copy()
             env['PYTHONUNBUFFERED'] = '1'
 
         # spawn task process
@@ -201,7 +206,7 @@ class CmdAction(BaseAction):
             #bufsize=2, # ??? no effect use PYTHONUNBUFFERED instead
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             env=env,
-            **self.pkwargs)
+            **subprocess_pkwargs)
 
         output = StringIO()
         errput = StringIO()

--- a/tests/sample_process.py
+++ b/tests/sample_process.py
@@ -1,11 +1,17 @@
 #! /usr/bin/env python
 
 # tests on CmdTask will use this script as an external process.
-# 3 or more arguments. process return error exit (166)
-# arguments "please fail". process return fail exit (11)
-# first argument is sent to stdout
-# second argument is sent to stderr
+# - If you call this script with 3 or more arguments, the process returns
+#   exit code (166).
+# - If you call this script with arguments "please fail", it returns exit
+#   code (11).
+# - If you call this script with arguments "check env", it verifies the
+#   existence of an environment variable called "GELKIPWDUZLOVSXE", with
+#   value "1". If the variable is not found, the process returns exit code (99).
+# - Otherwise, any first argument gets written to STDOUT. Any second argument
+#   gets written to STDERR.
 
+import os
 import sys
 
 if __name__ == "__main__":
@@ -17,6 +23,12 @@ if __name__ == "__main__":
         sys.stdout.write("out ouch")
         sys.stderr.write("err output on failure")
         sys.exit(11)
+    # check env
+    if len(sys.argv) == 3 and sys.argv[1]=='check' and sys.argv[2]=='env':
+        if os.environ.get('GELKIPWDUZLOVSXE') == '1':
+            sys.exit(0)
+        else:
+            sys.exit(99)
     # ok
     if len(sys.argv) > 1:
         sys.stdout.write(sys.argv[1])

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -59,7 +59,9 @@ class TestCmdAction(object):
         assert isinstance(got, TaskError)
 
     def test_env(self):
-        my_action = action.CmdAction("%s check env" % PROGRAM, env={'GELKIPWDUZLOVSXE': '1'})
+        env = os.environ.copy()
+        env['GELKIPWDUZLOVSXE'] = '1'
+        my_action = action.CmdAction("%s check env" % PROGRAM, env=env)
         got = my_action.execute()
         assert got is None
 

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -58,6 +58,11 @@ class TestCmdAction(object):
         got = my_action.execute()
         assert isinstance(got, TaskError)
 
+    def test_env(self):
+        my_action = action.CmdAction("%s check env" % PROGRAM, env={'GELKIPWDUZLOVSXE': '1'})
+        got = my_action.execute()
+        assert got is None
+
     def test_failure(self):
         my_action = action.CmdAction("%s please fail" % PROGRAM)
         got = my_action.execute()


### PR DESCRIPTION
This should fix #171. It also includes a small test for passing environment variables to subprocesses.