### PR TITLE
add code and output samples for private tasks

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -500,6 +500,27 @@ private/hidden tasks
 
 If task name starts with an underscore '_', it will not be included in the output.
 
+.. literalinclude:: tutorial/private_task.py
+
+.. code_block:: console
+
+    $ doit
+    .  hello
+    $ doit dumpdb
+    DBM type is 'dbm.gnu'
+    b'_private_get_username' -> {   '_values_:': {},
+        'checker:': 'MD5Checker',
+        'deps:': [],
+        'result:': '72c5fe66e904745607b30bff453bb75c'}
+    b'hello' -> {   '_values_:': {},
+        'checker:': 'MD5Checker',
+        'deps:': [],
+        'result:': 'b1946ac92492d2347c6235b4d2611184'}
+    b'_other_get_username' -> {   '_values_:': {},
+        'checker:': 'MD5Checker',
+        'deps:': [],
+        'result:': '46d3971fa3086160444faada1539e93b'}
+
 
 title
 -------

--- a/doc/tutorial/private_task.py
+++ b/doc/tutorial/private_task.py
@@ -1,0 +1,16 @@
+def task__private_get_username():
+    return {
+        'actions': ['echo whoami']
+    }
+
+
+def task_other_private_get_username():
+    return {
+        'actions': ['echo $USER'],
+        'basename': '_other_get_username'
+    }
+
+def task_hello():
+    return {
+        'actions': ['echo hello']
+        }


### PR DESCRIPTION
Adds a little more flavor documentation to the private tasks explanations.