### PR TITLE
Use `executable` from `sys` module instead of hardcoded `python`

### DIFF
--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,5 +1,7 @@
 import subprocess
+from sys import executable
+
 
 def test_execute(depfile_name):
-    assert 0 == subprocess.call(['python', '-m', 'doit', 'list',
+    assert 0 == subprocess.call([executable, '-m', 'doit', 'list',
                                  '--db-file', depfile_name])

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -3,6 +3,7 @@ import time
 import sys
 import tempfile
 import uuid
+from sys import executable
 
 import pytest
 
@@ -16,7 +17,7 @@ from .conftest import get_abspath, depfile
 
 #path to test folder
 TEST_PATH = os.path.dirname(__file__)
-PROGRAM = "python %s/sample_process.py" % TEST_PATH
+PROGRAM = "%s %s/sample_process.py" % (executable, TEST_PATH)
 
 
 def test_unicode_md5():

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -2,6 +2,7 @@ import os, shutil
 import tempfile
 from io import StringIO
 from pathlib import Path, PurePath
+from sys import executable
 
 import pytest
 
@@ -12,7 +13,7 @@ from doit import task
 
 #path to test folder
 TEST_PATH = os.path.dirname(__file__)
-PROGRAM = "python %s/sample_process.py" % TEST_PATH
+PROGRAM = "%s %s/sample_process.py" % (executable, TEST_PATH)
 
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import operator
+from sys import executable
 
 import pytest
 
@@ -216,7 +217,7 @@ class TestCheckTimestampUnchanged(object):
 class TestLongRunning(object):
     def test_success(self):
         TEST_PATH = os.path.dirname(__file__)
-        PROGRAM = "python %s/sample_process.py" % TEST_PATH
+        PROGRAM = "%s %s/sample_process.py" % (executable, TEST_PATH)
         my_action = tools.LongRunning(PROGRAM + " please fail")
         got = my_action.execute()
         assert got is None
@@ -235,14 +236,14 @@ class TestLongRunning(object):
 class TestInteractive(object):
     def test_fail(self):
         TEST_PATH = os.path.dirname(__file__)
-        PROGRAM = "python %s/sample_process.py" % TEST_PATH
+        PROGRAM = "%s %s/sample_process.py" % (executable, TEST_PATH)
         my_action = tools.Interactive(PROGRAM + " please fail")
         got = my_action.execute()
         assert isinstance(got, exceptions.TaskFailed)
 
     def test_success(self):
         TEST_PATH = os.path.dirname(__file__)
-        PROGRAM = "python %s/sample_process.py" % TEST_PATH
+        PROGRAM = "%s %s/sample_process.py" % (executable, TEST_PATH)
         my_action = tools.Interactive(PROGRAM + " ok")
         got = my_action.execute()
         assert got is None


### PR DESCRIPTION
Hello.

I met this issue when trying to run tests of doit module on a Python3-only system. Problem is that on a lot of systems `python` still means Python 2 and when you have only Python 3 installed, there is no `python` command at all.

I think that the best will be to execute commands inside test suite under the same Python as test suite itself.

This fix will also enable to run the test suite with various Python versions.

What do you think?