### PR TITLE
Use load_ipython_extension to register doit magic functions

### DIFF
--- a/doc/tools.rst
+++ b/doc/tools.rst
@@ -78,8 +78,7 @@ First you need to register the new magic function into ipython shell.
 
 .. code-block:: pycon
 
-    >>> from doit.tools import register_doit_as_IPython_magic
-    >>> register_doit_as_IPython_magic()
+    >>> %load_ext doit.tools
 
 
 .. Tip::
@@ -89,8 +88,8 @@ First you need to register the new magic function into ipython shell.
     (i.e. :file:`~/.ipython/profile_default/startup/doit_magic.ipy`)
     with the following content::
 
-        from doit.tools import register_doit_as_IPython_magic
-        register_doit_as_IPython_magic()
+        from doit.tools import load_ipython_extension
+        load_ipython_extension()
 
 Then you can define your `task_creator` functions and invoke them with `%doit`
 magic-function, instead of invoking the cmd-line script with a :file:`dodo.py`

--- a/doit/__init__.py
+++ b/doit/__init__.py
@@ -32,6 +32,7 @@ from doit import loader
 from doit.loader import create_after
 from doit.doit_cmd import get_var
 from doit.api import run
+from doit.tools import load_ipython_extension
 
 __all__ = ['get_var', 'run', 'create_after']
 

--- a/doit/__init__.py
+++ b/doit/__init__.py
@@ -39,3 +39,5 @@ __all__ = ['get_var', 'run', 'create_after']
 def get_initial_workdir():
     """working-directory from where the doit command was invoked on shell"""
     return loader.initial_workdir
+
+assert load_ipython_extension  # silence pyflakes

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -294,3 +294,6 @@ def load_ipython_extension(ip=None):  # pragma: no cover
         commander = DoitMain(ModuleTaskLoader(ip.user_module),
                              extra_config={'GLOBAL': opt_vals})
         commander.run(line.split())
+
+# the name register_doit_as_IPython_magic is deprecated on **
+register_doit_as_IPython_magic = load_ipython_extension

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -237,7 +237,7 @@ def set_trace(): # pragma: no cover
 
 
 
-def register_doit_as_IPython_magic():  # pragma: no cover
+def load_ipython_extension(ip=None):  # pragma: no cover
     """
     Defines a ``%doit`` magic function[1] that discovers and execute tasks
     from IPython's interactive variables (global namespace).
@@ -250,16 +250,20 @@ def register_doit_as_IPython_magic():  # pragma: no cover
         (``~/.ipython/profile_default/startup/doit_magic.ipy``) with the
         following content:
 
-            from doit.tools import register_doit_as_IPython_magic
-            register_doit_as_IPython_magic()
+            %load_ext doit.tools
+            %reload_ext doit.tools
+            %doit list
 
     [1] http://ipython.org/ipython-doc/dev/interactive/tutorial.html#magic-functions
     """
-    from IPython.core.magic import register_line_magic
     from IPython.core.getipython import get_ipython
+    from IPython.core.magic import register_line_magic
 
     from doit.cmd_base import ModuleTaskLoader
     from doit.doit_cmd import DoitMain
+
+    # Only (re)load_ext provides the ip context.
+    ip = ip or get_ipython()
 
     @register_line_magic
     def doit(line):
@@ -283,7 +287,6 @@ def register_doit_as_IPython_magic():  # pragma: no cover
             hi IPython
 
         """
-        ip = get_ipython()
         # Override db-files location inside ipython-profile dir,
         # which is certainly writable.
         prof_dir = ip.profile_dir.location


### PR DESCRIPTION
With this update

```ipython
%load_ext doit.tools
```
replaces

```ipython
from doit.tools import register_doit_as_IPython_magic
register_doit_as_IPython_magic()
```
This works using [`load_ipython_extension`](http://ipython.readthedocs.io/en/stable/config/extensions/#writing-extensions) instead of `register_doit_as_IPython_magic` .

[Here is an example notebook with this change.](http://nbviewer.jupyter.org/gist/tonyfast/46dcf89845ec319288c59aebd5fa75bc)