### PR TITLE
added option to forget during clean

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@
  * Gerlad Storer - https://github.com/gstorer
  * Simon Mutch - https://github.com/smutch
  * Michael Milton - https://github.com/tmiguelt
+ * Mike Pagel - https://github.com/moltob

--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Changes
  - CmdParse now support getting values from OS environment variables
  - option `seek_file` control by ENV var `DOIT_SEEK_FILE`
  - GH-#192 ipython extension uses `load_ipython_extension`
+ - GH-#218 clean can be called with option `--hard` to also forget about clean tasks
 
 
 0.30.3 (*2017-02-20*)

--- a/CHANGES
+++ b/CHANGES
@@ -13,8 +13,7 @@ Changes
  - CmdParse now support getting values from OS environment variables
  - option `seek_file` control by ENV var `DOIT_SEEK_FILE`
  - GH-#192 ipython extension uses `load_ipython_extension`
- - GH-#218 clean with option `--hard` or configuration option `clean_hard` can be used to also
-   forget about cleaned tasks
+ - GH-#218 clean with option `--clean-forget` can be used to also forget about cleaned tasks
 
 
 0.30.3 (*2017-02-20*)

--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,7 @@ Changes
  - CmdParse now support getting values from OS environment variables
  - option `seek_file` control by ENV var `DOIT_SEEK_FILE`
  - GH-#192 ipython extension uses `load_ipython_extension`
- - GH-#218 clean with option `--clean-forget` can be used to also forget about cleaned tasks
+ - GH-#218 clean with option `--forget` can be used to also forget about cleaned tasks
 
 
 0.30.3 (*2017-02-20*)

--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,8 @@ Changes
  - CmdParse now support getting values from OS environment variables
  - option `seek_file` control by ENV var `DOIT_SEEK_FILE`
  - GH-#192 ipython extension uses `load_ipython_extension`
- - GH-#218 clean can be called with option `--hard` to also forget about clean tasks
+ - GH-#218 clean with option `--hard` or configuration option `clean_hard` can be used to also
+   forget about cleaned tasks
 
 
 0.30.3 (*2017-02-20*)

--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -148,8 +148,14 @@ If you are executing the default tasks this flag is automatically set.
 
 If you want check which tasks the clean operation would affect you can use the option *-n*/*--dry-run*.
 
-If you like to also make doit forget previous execution of cleaned tasks, use option *--hard*.
+If you like to also make doit forget previous execution of cleaned tasks, use option *--hard*. This
+can be made the default behavior by adding the corresponding ``clean_hard`` configuration switch:
 
+.. code-block:: python
+
+    DOIT_CONFIG = {
+        'clean_hard': True,
+    }
 
 
 ignore

--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -148,13 +148,14 @@ If you are executing the default tasks this flag is automatically set.
 
 If you want check which tasks the clean operation would affect you can use the option *-n*/*--dry-run*.
 
-If you like to also make doit forget previous execution of cleaned tasks, use option *--hard*. This
-can be made the default behavior by adding the corresponding ``clean_hard`` configuration switch:
+If you like to also make doit forget previous execution of cleaned tasks, use option
+*--clean-forget*. This can be made the default behavior by adding the corresponding ``cleanforget``
+configuration switch:
 
 .. code-block:: python
 
     DOIT_CONFIG = {
-        'clean_hard': True,
+        'cleanforget': True,
     }
 
 

--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -149,7 +149,7 @@ If you are executing the default tasks this flag is automatically set.
 If you want check which tasks the clean operation would affect you can use the option *-n*/*--dry-run*.
 
 If you like to also make doit forget previous execution of cleaned tasks, use option
-*--clean-forget*. This can be made the default behavior by adding the corresponding ``cleanforget``
+*--forget*. This can be made the default behavior by adding the corresponding ``cleanforget``
 configuration switch:
 
 .. code-block:: python

--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -148,6 +148,8 @@ If you are executing the default tasks this flag is automatically set.
 
 If you want check which tasks the clean operation would affect you can use the option *-n*/*--dry-run*.
 
+If you like to also make doit forget previous execution of cleaned tasks, use option *--hard*.
+
 
 
 ignore

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -31,7 +31,7 @@ opt_clean_cleanall = {
 
 opt_clean_forget = {
     'name': 'cleanforget',
-    'long': 'clean-forget',
+    'long': 'forget',
     'type': bool,
     'default': False,
     'help': 'also forget tasks after cleaning',

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -57,8 +57,7 @@ class Clean(DoitCmdBase):
                 if forget_tasks:
                     self.dep_manager.remove(task.name)
 
-        if forget_tasks:
-            self.dep_manager.close()
+        self.dep_manager.close()
 
     def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None, clean_hard=False):
         """Clean tasks

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -46,14 +46,19 @@ class Clean(DoitCmdBase):
     cmd_options = (opt_clean_cleandep, opt_clean_cleanall, opt_clean_dryrun, opt_clean_hard)
 
 
-    def clean_tasks(self, tasks, dryrun):
+    def clean_tasks(self, tasks, dryrun, hard):
         """ensure task clean-action is executed only once"""
         cleaned = set()
+        forget_tasks = hard and not dryrun
         for task in tasks:
             if task.name not in cleaned:
                 cleaned.add(task.name)
                 task.clean(self.outstream, dryrun)
+                if forget_tasks:
+                    self.dep_manager.remove(task.name)
 
+        if forget_tasks:
+            self.dep_manager.close()
 
     def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None):
         """Clean tasks
@@ -98,4 +103,4 @@ class Clean(DoitCmdBase):
                 to_clean.append(task)
                 to_clean.extend(subtasks_iter(tasks, task))
         to_clean.reverse()
-        self.clean_tasks(to_clean, dryrun)
+        self.clean_tasks(to_clean, dryrun, hard)

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -29,6 +29,13 @@ opt_clean_cleanall = {
     'help': 'clean all task',
     }
 
+opt_clean_hard = {
+    'name': 'hard',
+    'long': 'hard',
+    'type': bool,
+    'default': False,
+    'help': 'also forget tasks after cleaning',
+    }
 
 class Clean(DoitCmdBase):
     doc_purpose = "clean action / remove targets"
@@ -36,7 +43,7 @@ class Clean(DoitCmdBase):
     doc_description = ("If no task is specified clean default tasks and "
                        "set --clean-dep automatically.")
 
-    cmd_options = (opt_clean_cleandep, opt_clean_cleanall, opt_clean_dryrun)
+    cmd_options = (opt_clean_cleandep, opt_clean_cleanall, opt_clean_dryrun, opt_clean_hard)
 
 
     def clean_tasks(self, tasks, dryrun):
@@ -48,7 +55,7 @@ class Clean(DoitCmdBase):
                 task.clean(self.outstream, dryrun)
 
 
-    def _execute(self, dryrun, cleandep, cleanall, pos_args=None):
+    def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None):
         """Clean tasks
         @param task_list (list - L{Task}): list of all tasks from dodo file
         @ivar dryrun (bool): if True clean tasks are not executed

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -29,9 +29,9 @@ opt_clean_cleanall = {
     'help': 'clean all task',
     }
 
-opt_clean_hard = {
-    'name': 'hard',
-    'long': 'hard',
+opt_clean_forget = {
+    'name': 'cleanforget',
+    'long': 'clean-forget',
     'type': bool,
     'default': False,
     'help': 'also forget tasks after cleaning',
@@ -43,13 +43,13 @@ class Clean(DoitCmdBase):
     doc_description = ("If no task is specified clean default tasks and "
                        "set --clean-dep automatically.")
 
-    cmd_options = (opt_clean_cleandep, opt_clean_cleanall, opt_clean_dryrun, opt_clean_hard)
+    cmd_options = (opt_clean_cleandep, opt_clean_cleanall, opt_clean_dryrun, opt_clean_forget)
 
 
-    def clean_tasks(self, tasks, dryrun, hard):
+    def clean_tasks(self, tasks, dryrun, cleanforget):
         """ensure task clean-action is executed only once"""
         cleaned = set()
-        forget_tasks = hard and not dryrun
+        forget_tasks = cleanforget and not dryrun
         for task in tasks:
             if task.name not in cleaned:
                 cleaned.add(task.name)
@@ -59,15 +59,14 @@ class Clean(DoitCmdBase):
 
         self.dep_manager.close()
 
-    def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None, clean_hard=False):
+    def _execute(self, dryrun, cleandep, cleanall, cleanforget, pos_args=None):
         """Clean tasks
         @param task_list (list - L{Task}): list of all tasks from dodo file
         @ivar dryrun (bool): if True clean tasks are not executed
                             (just print out what would be executed)
         @param cleandep (bool): execute clean from task_dep
         @param cleanall (bool): clean all tasks
-        @param hard (bool): forget cleaned tasks (command line option)
-        @param clean_hard (bool): forget cleaned tasks (doit config parameter)
+        @param cleanforget (bool): forget cleaned tasks
         @var default_tasks (list - string): list of default tasks
         @var selected_tasks (list - string): list of tasks selected
                                              from cmd-line
@@ -104,4 +103,4 @@ class Clean(DoitCmdBase):
                 to_clean.append(task)
                 to_clean.extend(subtasks_iter(tasks, task))
         to_clean.reverse()
-        self.clean_tasks(to_clean, dryrun, hard or clean_hard)
+        self.clean_tasks(to_clean, dryrun, cleanforget)

--- a/doit/cmd_clean.py
+++ b/doit/cmd_clean.py
@@ -60,13 +60,15 @@ class Clean(DoitCmdBase):
         if forget_tasks:
             self.dep_manager.close()
 
-    def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None):
+    def _execute(self, dryrun, cleandep, cleanall, hard, pos_args=None, clean_hard=False):
         """Clean tasks
         @param task_list (list - L{Task}): list of all tasks from dodo file
         @ivar dryrun (bool): if True clean tasks are not executed
                             (just print out what would be executed)
         @param cleandep (bool): execute clean from task_dep
         @param cleanall (bool): clean all tasks
+        @param hard (bool): forget cleaned tasks (command line option)
+        @param clean_hard (bool): forget cleaned tasks (doit config parameter)
         @var default_tasks (list - string): list of default tasks
         @var selected_tasks (list - string): list of tasks selected
                                              from cmd-line
@@ -103,4 +105,4 @@ class Clean(DoitCmdBase):
                 to_clean.append(task)
                 to_clean.extend(subtasks_iter(tasks, task))
         to_clean.reverse()
-        self.clean_tasks(to_clean, dryrun, hard)
+        self.clean_tasks(to_clean, dryrun, hard or clean_hard)

--- a/tests/test_cmd_clean.py
+++ b/tests/test_cmd_clean.py
@@ -25,21 +25,23 @@ class TestCmdClean(object):
 
     def test_clean_all(self, tasks):
         output = StringIO()
-        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
+        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
+                               dep_manager=mock.MagicMock())
         cmd_clean._execute(False, False, True, False)
         assert ['t1','t2', 't3:a', 't3', 't4'] == self.cleaned
 
     def test_clean_default(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
-                               sel_tasks=['t1'])
+                               sel_tasks=['t1'], dep_manager=mock.MagicMock())
         cmd_clean._execute(False, False, False, False)
         # default enable --clean-dep by default
         assert ['t2', 't1'] == self.cleaned
 
     def test_clean_default_all(self, tasks):
         output = StringIO()
-        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
+        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
+                               dep_manager=mock.MagicMock())
         cmd_clean._execute(False, False, False, False)
         # default enable --clean-dep by default
         assert set(['t1','t2', 't3:a', 't3', 't4']) == set(self.cleaned)
@@ -64,20 +66,23 @@ class TestCmdClean(object):
 
     def test_clean_taskdep_recursive(self, tasks):
         output = StringIO()
-        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
+        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
+                               dep_manager=mock.MagicMock())
         cmd_clean._execute(False, True, False, False, ['t4'])
         assert ['t2', 't1', 't4'] == self.cleaned
 
     def test_clean_subtasks(self, tasks):
         output = StringIO()
-        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
+        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
+                               dep_manager=mock.MagicMock())
         cmd_clean._execute(False, False, False, False, ['t3'])
         assert ['t3:a', 't3'] == self.cleaned
 
     def test_clean_taskdep_once(self, tasks):
         # do not execute clean operation more than once
         output = StringIO()
-        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
+        cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
+                               dep_manager=mock.MagicMock())
         cmd_clean._execute(False, True, False, False, ['t1', 't2'])
         assert ['t2', 't1'] == self.cleaned
 

--- a/tests/test_cmd_clean.py
+++ b/tests/test_cmd_clean.py
@@ -25,21 +25,21 @@ class TestCmdClean(object):
     def test_clean_all(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, False, True)
+        cmd_clean._execute(False, False, True, False)
         assert ['t1','t2', 't3:a', 't3', 't4'] == self.cleaned
 
     def test_clean_default(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
                                sel_tasks=['t1'])
-        cmd_clean._execute(False, False, False)
+        cmd_clean._execute(False, False, False, False)
         # default enable --clean-dep by default
         assert ['t2', 't1'] == self.cleaned
 
     def test_clean_default_all(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, False, False)
+        cmd_clean._execute(False, False, False, False)
         # default enable --clean-dep by default
         assert set(['t1','t2', 't3:a', 't3', 't4']) == set(self.cleaned)
 
@@ -47,32 +47,32 @@ class TestCmdClean(object):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
                                sel_tasks=['t1'])
-        cmd_clean._execute(False, False, False, ['t2'])
+        cmd_clean._execute(False, False, False, False, ['t2'])
         assert ['t2'] == self.cleaned
 
     def test_clean_taskdep(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, True, False, ['t1'])
+        cmd_clean._execute(False, True, False, False, ['t1'])
         assert ['t2', 't1'] == self.cleaned
 
     def test_clean_taskdep_recursive(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, True, False, ['t4'])
+        cmd_clean._execute(False, True, False, False, ['t4'])
         assert ['t2', 't1', 't4'] == self.cleaned
 
     def test_clean_subtasks(self, tasks):
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, False, False, ['t3'])
+        cmd_clean._execute(False, False, False, False, ['t3'])
         assert ['t3:a', 't3'] == self.cleaned
 
     def test_clean_taskdep_once(self, tasks):
         # do not execute clean operation more than once
         output = StringIO()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks)
-        cmd_clean._execute(False, True, False, ['t1', 't2'])
+        cmd_clean._execute(False, True, False, False, ['t1', 't2'])
         assert ['t2', 't1'] == self.cleaned
 
     def test_clean_invalid_task(self, tasks):
@@ -80,4 +80,4 @@ class TestCmdClean(object):
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
                                sel_tasks=['t1'])
         pytest.raises(InvalidCommand, cmd_clean._execute,
-                      False, False, False, ['xxxx'])
+                      False, False, False, False, ['xxxx'])

--- a/tests/test_cmd_clean.py
+++ b/tests/test_cmd_clean.py
@@ -93,7 +93,7 @@ class TestCmdClean(object):
         pytest.raises(InvalidCommand, cmd_clean._execute,
                       False, False, False, False, ['xxxx'])
 
-    def test_clean_hard_selected(self, tasks):
+    def test_clean_forget_selected(self, tasks):
         output = StringIO()
         mock_dep_manager = mock.MagicMock()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,
@@ -103,7 +103,7 @@ class TestCmdClean(object):
         mock_dep_manager.assert_has_calls([mock.call.remove(mock.ANY), mock.call.close()])  # order
         assert mock_dep_manager.remove.call_args_list == [mock.call('t2')]  # exactly t2, not more
 
-    def test_clean_hard_taskdep(self, tasks):
+    def test_clean_forget_taskdep(self, tasks):
         output = StringIO()
         mock_dep_manager = mock.MagicMock()
         cmd_clean = CmdFactory(Clean, outstream=output, task_list=tasks,


### PR DESCRIPTION
Clean can now also forget about previous task execution be either adding the `--hard` option or by specifying `clean_hard=True` during doit configuration, see updated docs and unit tests.

This implements the feature request in #218.