### PR TITLE
Add option to delay the start of processes

### DIFF
--- a/doc/tasks.rst
+++ b/doc/tasks.rst
@@ -596,6 +596,32 @@ You can control the verbosity by:
 * from command line, see :ref:`verbosity option<verbosity_option>`.
 
 
+delayed execution
+-----------------
+
+For :ref:`parallel execution <parallel-execution>` it can be useful to delay
+the start of the first task executed in a process. This can be achieved with
+the ``delay`` option:
+
+.. literalinclude:: tutorial/subtasks-delay.py
+
+.. code-block:: console
+
+    $ doit run -v 2 -n 2
+    task file0.txt started (H:M:S+57)
+    .  create_file:file0.txt
+    .  create_file:file1.txt
+    .  create_file:file2.txt
+    task file1.txt started (H:M:S+59)
+    task file2.txt started (H:M:S+59)
+    .  create_file:file3.txt
+    .  create_file:file4.txt
+    task file3.txt started (H:M:S+59)
+    task file4.txt started (H:M:S+59)
+    .  create_file:file5.txt
+    task file5.txt started (H:M:S+59)
+
+
 pathlib
 --------
 

--- a/doc/tutorial/subtasks-delay.py
+++ b/doc/tutorial/subtasks-delay.py
@@ -1,0 +1,7 @@
+def task_create_file():
+    for i in range(6):
+        filename = "file%d.txt" % i
+        yield {'name': filename,
+               'delay': 2,
+               'actions': ['echo "task {} started (H:M:S+`date +%%S`)"'
+                           .format(filename)]}

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -5,6 +5,7 @@ from multiprocessing import Process, Queue as MQueue
 from threading import Thread
 import pickle
 import queue
+import time
 
 import cloudpickle
 
@@ -411,8 +412,15 @@ class MRunner(Runner):
         # ### END DEBUG
 
         proc_list = []
-        for _ in range(self.num_process):
+        for i in range(self.num_process):
             next_job = self.get_next_job(None)
+            try:
+                delay = next_job.task_dict.get('delay') or 0
+            except AttributeError:
+                pass
+            else:
+                if i > 0 and delay:
+                    time.sleep(delay)
             if next_job is None:
                 break # do not start more processes than tasks
             job_q.put(next_job)

--- a/doit/task.py
+++ b/doit/task.py
@@ -110,6 +110,7 @@ class Task(object):
                   'getargs': ((dict,), ()),
                   'title': ((types.FunctionType,), (None,)),
                   'watch': ((list, tuple), ()),
+                  'delay': ((float, int), (None, )),
     }
 
 
@@ -119,7 +120,7 @@ class Task(object):
                  is_subtask=False, has_subtask=False,
                  doc=None, params=(), pos_arg=None,
                  verbosity=None, title=None, getargs=None,
-                 watch=(), loader=None):
+                 watch=(), loader=None, delay=None):
         """sanity checks and initialization
 
         @param params: (list of dict for parameters) see cmdparse.CmdOption
@@ -145,6 +146,7 @@ class Task(object):
         self.check_attr(name, 'getargs', getargs, self.valid_attr['getargs'])
         self.check_attr(name, 'title', title, self.valid_attr['title'])
         self.check_attr(name, 'watch', watch, self.valid_attr['watch'])
+        self.check_attr(name, 'delay', delay, self.valid_attr['delay'])
 
         if '=' in name:
             msg = "Task '{}': name must not use the char '=' (equal sign)."
@@ -198,6 +200,7 @@ class Task(object):
         self.teardown = [create_action(a, self) for a in teardown]
         self.doc = self._init_doc(doc)
         self.watch = watch
+        self.delay = delay
 
 
     def _init_deps(self, file_dep, task_dep, calc_dep):


### PR DESCRIPTION
Because it is sometimes useful to avoid having all the processes doing the same thing (I/O, OpenMP blocks) at the same time.