### PR TITLE
Enhance readability of the info cmd, and print status by default.

### DIFF
--- a/doit/cmd_info.py
+++ b/doit/cmd_info.py
@@ -6,14 +6,13 @@ from .cmd_base import DoitCmdBase
 from .exceptions import InvalidCommand
 
 
-
-opt_show_execute_status = {
-    'name': 'show_execute_status',
-    'short': 's',
-    'long': 'status',
+opt_hide_execute_status = {
+    'name': 'hide_execute_status',
+    # 'short': 's',
+    'long': 'no-status',
     'type': bool,
-    'default': True,
-    'help': """Shows reasons why this task would be executed.
+    'default': False,
+    'help': """Hides reasons why this task would be executed.
  [default: %(default)s]"""
 }
 
@@ -25,9 +24,9 @@ class Info(DoitCmdBase):
     doc_usage = "TASK"
     doc_description = None
 
-    cmd_options = (opt_show_execute_status, )
+    cmd_options = (opt_hide_execute_status, )
 
-    def _execute(self, pos_args, show_execute_status=True):
+    def _execute(self, pos_args, hide_execute_status=False):
         if len(pos_args) != 1:
             msg = ('`info` failed, must select *one* task.'
                    '\nCheck `{} help info`.'.format(self.bin_name))
@@ -53,7 +52,7 @@ class Info(DoitCmdBase):
 
         # print reason task is not up-to-date
         retcode = 0
-        if show_execute_status and self.dep_manager is not None:
+        if not hide_execute_status and self.dep_manager is not None:
             status = self.dep_manager.get_status(task, tasks, get_log=True)
             self.outstream.write('\n{:11s}: {}\n'
                                  .format('status', status.status))

--- a/doit/cmd_info.py
+++ b/doit/cmd_info.py
@@ -12,7 +12,7 @@ opt_show_execute_status = {
     'short': 's',
     'long': 'status',
     'type': bool,
-    'default': False,
+    'default': True,
     'help': """Shows reasons why this task would be executed.
  [default: %(default)s]"""
 }
@@ -27,7 +27,7 @@ class Info(DoitCmdBase):
 
     cmd_options = (opt_show_execute_status, )
 
-    def _execute(self, pos_args, show_execute_status=False):
+    def _execute(self, pos_args, show_execute_status=True):
         if len(pos_args) != 1:
             msg = ('`info` failed, must select *one* task.'
                    '\nCheck `{} help info`.'.format(self.bin_name))
@@ -41,31 +41,40 @@ class Info(DoitCmdBase):
 
         task = tasks[task_name]
         task_attrs = (
-            'name', 'file_dep', 'task_dep', 'setup_tasks', 'calc_dep',
-            'targets',
+            'file_dep', 'task_dep', 'setup_tasks', 'calc_dep', 'targets',
             # these fields usually contains reference to python functions
             # 'actions', 'clean', 'uptodate', 'teardown', 'title'
             'getargs', 'params', 'verbosity', 'watch'
         )
+
+        self.outstream.write('\n{}\n'.format(task.name))
+        if task.doc:
+            self.outstream.write('\n{}\n'.format(task.doc))
+
+        # print reason task is not up-to-date
+        retcode = 0
+        if show_execute_status and self.dep_manager is not None:
+            status = self.dep_manager.get_status(task, tasks, get_log=True)
+            self.outstream.write('\n{:11s}: {}\n'
+                                 .format('status', status.status))
+            if status.status != 'up-to-date':
+                # status.status == 'run' or status.status == 'error'
+                self.outstream.write(self.get_reasons(status.reasons))
+                self.outstream.write('\n')
+                retcode = 1
+
         for attr in task_attrs:
             value = getattr(task, attr)
             # by default only print fields that have non-empty value
             if value:
-                self.outstream.write('\n{0}:'.format(attr))
-                printer.pprint(getattr(task, attr))
+                self.outstream.write('\n{:11s}:\n'.format(attr))
+                try:
+                    for val in value:
+                        self.outstream.write(' - {}\n'.format(val))
+                except:
+                    printer.pprint(getattr(task, attr))
 
-        # print reason task is not up-to-date
-        if show_execute_status:
-            status = self.dep_manager.get_status(task, tasks, get_log=True)
-            if status.status == 'up-to-date':
-                self.outstream.write('\nTask is up-to-date.\n')
-                return 0
-            else:  # status.status == 'run' or status.status == 'error'
-                self.outstream.write('\nTask is not up-to-date:\n')
-                self.outstream.write(self.get_reasons(status.reasons))
-                self.outstream.write('\n')
-                return 1
-
+        return retcode
 
     @staticmethod
     def get_reasons(reasons):

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -27,7 +27,7 @@ def flat_generator(gen, gen_doc=''):
         if inspect.isgenerator(item):
             item_doc = item.gi_code.co_consts[0]
             for value, value_doc in flat_generator(item, item_doc):
-                yield value, value_doc
+                yield value, value_doc or gen_doc
         else:
             yield item, gen_doc
 

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -171,8 +171,8 @@ def _get_task_creators(namespace, command_names):
     for name, ref in namespace.items():
 
         # function is a task creator because of its name
-        if ((inspect.isfunction(ref) or inspect.ismethod(ref)) and
-            name.startswith(TASK_STRING)):
+        if name.startswith(TASK_STRING) and (
+                inspect.isfunction(ref) or inspect.ismethod(ref)):
             # remove TASK_STRING prefix from name
             task_name = name[prefix_len:]
 

--- a/tests/test_cmd_info.py
+++ b/tests/test_cmd_info.py
@@ -43,7 +43,7 @@ class TestCmdInfo(object):
         cmd = CmdFactory(Info, outstream=output,
                          dep_file=depfile.name, task_list=[task],
                          backend='dbm')
-        return_val = cmd._execute(['t1'], show_execute_status=True)
+        return_val = cmd._execute(['t1'])
         assert """t1""" in output.getvalue()
         assert return_val == 1  # indicates task is not up-to-date
         assert "run" in output.getvalue()
@@ -56,10 +56,16 @@ class TestCmdInfo(object):
                          dep_file=depfile.name, task_list=[task],
                          backend='dbm')
         cmd.dep_manager.save_success(task)
-        return_val = cmd._execute(['t1'], show_execute_status=True)
+        return_val = cmd._execute(['t1'])
         assert """t1""" in output.getvalue()
         assert return_val == 0  # indicates task is not up-to-date
         assert "up-to-date" in output.getvalue()
+
+        output.seek(0)
+        return_val = cmd._execute(['t1'], hide_execute_status=True)
+        assert """t1""" in output.getvalue()
+        assert return_val == 0  # indicates task is not up-to-date
+        assert "up-to-date" not in output.getvalue()
 
     def test_get_reasons_str(self):
         reasons = {

--- a/tests/test_cmd_info.py
+++ b/tests/test_cmd_info.py
@@ -7,6 +7,7 @@ from doit.task import Task
 from doit.cmd_info import Info
 from .conftest import CmdFactory
 
+
 class TestCmdInfo(object):
 
     def test_info(self, depfile):
@@ -15,8 +16,17 @@ class TestCmdInfo(object):
         cmd = CmdFactory(Info, outstream=output,
                          dep_file=depfile.name, task_list=[task])
         cmd._execute(['t1'])
-        assert """name:'t1'""" in output.getvalue()
-        assert """'tests/data/dependency1'""" in output.getvalue()
+        assert """t1""" in output.getvalue()
+        assert """tests/data/dependency1""" in output.getvalue()
+
+    def test_info_unicode(self, depfile):
+        output = StringIO()
+        task = Task("t1", [], file_dep=['tests/data/dependency1'])
+        cmd = CmdFactory(Info, outstream=output,
+                         dep_file=depfile.name, task_list=[task])
+        cmd._execute(['t1'])
+        assert """t1""" in output.getvalue()
+        assert """tests/data/dependency1""" in output.getvalue()
 
     def test_invalid_command_args(self, depfile):
         output = StringIO()
@@ -34,9 +44,9 @@ class TestCmdInfo(object):
                          dep_file=depfile.name, task_list=[task],
                          backend='dbm')
         return_val = cmd._execute(['t1'], show_execute_status=True)
-        assert """name:'t1'""" in output.getvalue()
+        assert """t1""" in output.getvalue()
         assert return_val == 1  # indicates task is not up-to-date
-        assert "Task is not up-to-date" in output.getvalue()
+        assert "run" in output.getvalue()
         assert """ - tests/data/dependency1""" in output.getvalue()
 
     def test_execute_status_uptodate(self, depfile, dependency1):
@@ -47,10 +57,9 @@ class TestCmdInfo(object):
                          backend='dbm')
         cmd.dep_manager.save_success(task)
         return_val = cmd._execute(['t1'], show_execute_status=True)
-        assert """name:'t1'""" in output.getvalue()
+        assert """t1""" in output.getvalue()
         assert return_val == 0  # indicates task is not up-to-date
-        assert "Task is up-to-date" in output.getvalue()
-
+        assert "up-to-date" in output.getvalue()
 
     def test_get_reasons_str(self):
         reasons = {
@@ -69,4 +78,3 @@ class TestCmdInfo(object):
         assert got[4] == ' * The following targets do not exist:'
         assert got[5] == '    - f1'
         assert got[6] == '    - f2'
-


### PR DESCRIPTION
A few changes to make `doit info` nicer (imho): 

- Show the task docstring if it exists
- Better rendering for lists (`task_dep` etc.)
- And maybe controversial, show the status by default. I think that when using this command the status is one of the most useful information. 

Before:
```
❯ doit info ut

name:'ut'

task_dep:[   'ut:tests/test_loader.py',
    'ut:tests/test_cmd_resetdep.py',
    'ut:tests/test_doit_cmd.py',
    'ut:tests/test_cmd_info.py',
    'ut:tests/test_action.py',
    'ut:tests/test_cmd_base.py',
    'ut:tests/test_task.py',
    'ut:tests/test_cmd_ignore.py',
    'ut:tests/test_api.py',
    'ut:tests/test_cmd_auto.py',
    'ut:tests/test___init__.py',
    'ut:tests/test_cmd_run.py',
    'ut:tests/test_cmd_list.py',
    'ut:tests/test_exceptions.py',
    'ut:tests/test_control.py',
    'ut:tests/test_cmd_help.py',
    'ut:tests/test_cmd_completion.py',
    'ut:tests/test_reporter.py',
    'ut:tests/test_cmdparse.py',
    'ut:tests/test_cmd_strace.py',
    'ut:tests/test_cmd_forget.py',
    'ut:tests/test___main__.py',
    'ut:tests/test_tools.py',
    'ut:tests/test_cmd_clean.py',
    'ut:tests/test_plugin.py',
    'ut:tests/test_filewatch.py',
    'ut:tests/test_dependency.py',
    'ut:tests/test_runner.py',
    'ut:tests/test_cmd_dumpdb.py']
```
After:
```
❯ doit info ut

ut

run unit-tests

status     : run
 * The task has no dependencies.

task_dep   :
 - ut:tests/test_loader.py
 - ut:tests/test_cmd_resetdep.py
 - ut:tests/test_doit_cmd.py
 - ut:tests/test_cmd_info.py
 - ut:tests/test_action.py
 - ut:tests/test_cmd_base.py
 - ut:tests/test_task.py
 - ut:tests/test_cmd_ignore.py
 - ut:tests/test_api.py
 - ut:tests/test_cmd_auto.py
 - ut:tests/test___init__.py
 - ut:tests/test_cmd_run.py
 - ut:tests/test_cmd_list.py
 - ut:tests/test_exceptions.py
 - ut:tests/test_control.py
 - ut:tests/test_cmd_help.py
 - ut:tests/test_cmd_completion.py
 - ut:tests/test_reporter.py
 - ut:tests/test_cmdparse.py
 - ut:tests/test_cmd_strace.py
 - ut:tests/test_cmd_forget.py
 - ut:tests/test___main__.py
 - ut:tests/test_tools.py
 - ut:tests/test_cmd_clean.py
 - ut:tests/test_plugin.py
 - ut:tests/test_filewatch.py
 - ut:tests/test_dependency.py
 - ut:tests/test_runner.py
 - ut:tests/test_cmd_dumpdb.py
```