### PR TITLE
improve error message in actions to include the keyword

### DIFF
--- a/doit/action.py
+++ b/doit/action.py
@@ -444,7 +444,7 @@ class PythonAction(BaseAction):
         return "<PythonAction: '%s'>"% (repr(self.py_callable))
 
 
-def create_action(action, task_ref):
+def create_action(action, task_ref, keyword='*'):
     """
     Create action using proper constructor based on the parameter type
 
@@ -464,13 +464,13 @@ def create_action(action, task_ref):
 
     if isinstance(action, tuple):
         if len(action) > 3:
-            msg = "Task '%s': invalid 'actions' tuple length. got:%r %s"
-            raise InvalidTask(msg % (task_ref.name, action, type(action)))
+            msg = "Task '%s': invalid '%s' tuple length. got:%r %s"
+            raise InvalidTask(msg % (task_ref.name, keyword, action, type(action)))
         py_callable, args, kwargs = (list(action) + [None]*(3-len(action)))
         return PythonAction(py_callable, args, kwargs, task_ref)
 
     if hasattr(action, '__call__'):
         return PythonAction(action, task=task_ref)
 
-    msg = "Task '%s': invalid 'actions' type. got:%r %s"
-    raise InvalidTask(msg % (task_ref.name, action, type(action)))
+    msg = "Task '%s': invalid '%s' type. got:%r %s"
+    raise InvalidTask(msg % (task_ref.name, keyword, action, type(action)))

--- a/doit/task.py
+++ b/doit/task.py
@@ -193,9 +193,9 @@ class Task(object):
             self.clean_actions = ()
         else:
             self._remove_targets = False
-            self.clean_actions = [create_action(a, self) for a in clean]
+            self.clean_actions = [create_action(a, self, 'clean') for a in clean]
 
-        self.teardown = [create_action(a, self) for a in teardown]
+        self.teardown = [create_action(a, self, 'teardown') for a in teardown]
         self.doc = self._init_doc(doc)
         self.watch = watch
 
@@ -379,7 +379,7 @@ class Task(object):
         """lazy creation of action instances"""
         if self._action_instances is None:
             self._action_instances = [
-                create_action(a, self) for a in self._actions]
+                create_action(a, self, 'actions') for a in self._actions]
         return self._action_instances
 
 


### PR DESCRIPTION
Fixes #197 Misleading error message when using invalid "clean" value