### PR TITLE
[exceptions] Save caught exception as base_exc attribute.

### DIFF
--- a/doit/exceptions.py
+++ b/doit/exceptions.py
@@ -49,6 +49,7 @@ class CatchedException(object):
     def __init__(self, msg, exception=None):
         self.message = msg
         self.traceback = ''
+        self.base_exc = exception
 
         if isinstance(exception, CatchedException):
             self.traceback = exception.traceback


### PR DESCRIPTION
Reports may wish to make a decision based on the nature of the
underlying exception. In addition to the traceback the CatchedException
also retains the underlying exception as the base_exc attribute.

This is useful for custom tooling that is based on doit. If the task has already displayed a comprehensive error message to the user the Python stack trace is confusing. My custom reporter looks at the base exception and will suppress the stack trace as needed.