### PR TITLE
Travis CI: Enable Python 3.7 & pypy3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    # - "3.7"
     # - "pypy3" pypy3 implements py3.2 not supported anymore
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
 
 # when setting sudo to true, issues with strace are fixed
 # see: https://github.com/travis-ci/travis-ci/issues/9033

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ branches:
 script:
    - doit pyflakes
    - py.test --ignore-flaky
-   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then doit coverage; fi
+   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then doit coverage; fi
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then coveralls; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
 
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    # - "pypy3" pypy3 implements py3.2 not supported anymore
+    - "pypy3.5"
 
 matrix:
   include:


### PR DESCRIPTION
This switches to pypy3.5 (which is now implementing Python 3.5) and also enables the usage of Python 3.7 via the way described in Travis bugtracker (see #262).

Coverage reporting is made with Python 3.7 to make use of the latest Python version.