### PR TITLE
Avoid using pytest 4

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,7 +2,7 @@
 # $ pip install --requirement dev_requirements.txt
 
 pyflakes
-pytest>=2.8.0
+pytest>=2.8.0,<4.0
 pytest-ignore-flaky
 coverage>=4.0
 doit-py>=0.4.0


### PR DESCRIPTION
Tests are failing with the latest pytest (see #275).
This is a workaround to make running the tests works and should be removed once the tests work with the latest pytest.