### PR TITLE
Fix development setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,13 +147,13 @@ create a virtualenv...
 ::
 
   doit$ virtualenv dev
-  (dev)doit$ dev/bin/activate
+  doit$ source dev/bin/activate
 
 install ``doit`` as "editable", and add development dependencies
 from `dev_requirements.txt`::
 
-  (dev)doit$ pip install --editable .
-  (dev)doit$ pip install --requirement dev_requirements.txt
+  (dev) doit$ pip install --editable .
+  (dev) doit$ pip install --requirement dev_requirements.txt
 
 
 


### PR DESCRIPTION
dev/bin/activate isn't an executable script, you need to source the file
into your local environment. Following the instructions as they are now
results in a "not executable by this user" error.