### PR TITLE
Fix pathlib bug in tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ doc/samples/*.in
 doc/samples/*.out
 doc/samples/file*
 
-
+dev
+.vscode

--- a/doc/tutorial/tuto_1_1.py
+++ b/doc/tutorial/tuto_1_1.py
@@ -18,7 +18,7 @@ def module_to_dot(dependencies, targets):
     for dep in dependencies:
         filepath = pathlib.Path(dep)
         source = filepath.stem
-        with open(filepath) as fh:
+        with filepath.open() as fh:
             for line in fh:
                 sink = line.strip()
                 if sink:

--- a/doc/tutorial_1.rst
+++ b/doc/tutorial_1.rst
@@ -41,6 +41,7 @@ required python packages
 
   $ pip install doit pygraphviz import_deps
 
+Note that on some linux systems it is necessary to install the system package `graphviz-dev` first.
 
 sample project
 --------------

--- a/doc/tutorial_1.rst
+++ b/doc/tutorial_1.rst
@@ -622,7 +622,7 @@ key is the sub-task name:
 .. literalinclude:: tutorial/tuto_1_3.py
    :language: python3
    :lines: 25-41
-   :emphasize-lines: 5,15
+   :emphasize-lines: 5,13-15
 
 
 Finally, adjust task ``draw``.

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -2,4 +2,4 @@
 # $ pip install --requirement doc_requirements.txt
 
 sphinx
-
+sphinx_rtd_theme


### PR DESCRIPTION
Hey there,

Today I went through your tutorial and noticed a few things:
First I had to install the system package `graphviz-dev` for `pygraphviz` to be installed correctly. Not your fault, but I thought mentioning it will spare other people some time.
Then `import-dep` didn't run because there was a bug in pathlib usage. I've fixed that and opened a pull request there already.
Then I saw the same bug in the tutorial.

At first I thought I'd just open an issue, but then I thought it's so easy to fix that I might just as well *doit* myself. Less complaining, more doing :smile:

Anyway, here you go!
I've also fixed a few other things that I noticed along the way but not all of them.
The sample `report_deps.py` doesn't work and spellchecking also fails on a few files. I think `hunspell` should also be mentioned as a system dependency for working on the docs somewhere.
Those are rather unrelated and I don't really know what's the right way to fix them which is why I left them unsolved.