### PR TITLE
Solve issue #286 - task.title accept partials

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@
  * Marijn van Vliet - https://github.com/wmvanvliet
  * Niko Wenselowski - https://github.com/okin
  * Jan Felix Langenbach - o <dot> hase3 <at> gmail <dot> com
+ * Facundo Ciccioli - facundofc <at> gmail <dot> com

--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ Changes
  - Make it possible to use a custom encoder when using config_changed with a dict.
  - Add configuration `DOIT_CONFIG` `action_string_formatting` to control command action formatter.
  - Fix `result_dep`, use result **after** its execution
+ - Fix #286: Cannot use functools.partial as title
 
 
 0.31.1 (*2018-03-18*)

--- a/doit/task.py
+++ b/doit/task.py
@@ -407,9 +407,8 @@ class Task(object):
         @param valid (list): of valid types/value accepted
         @raises InvalidTask if invalid input
         """
-        for t in valid[0]:
-            if isinstance(value, t):
-                return
+        if isinstance(value, valid[0]):
+            return
         if value in valid[1]:
             return
 

--- a/doit/task.py
+++ b/doit/task.py
@@ -407,7 +407,7 @@ class Task(object):
         @param valid (list): of valid types/value accepted
         @raises InvalidTask if invalid input
         """
-        if isinstance(value, valid[0]):
+        if isinstance(value, tuple(valid[0])):
             return
         if value in valid[1]:
             return

--- a/doit/task.py
+++ b/doit/task.py
@@ -1,11 +1,11 @@
 
 """Tasks are the main abstractions managed by doit"""
 
-import types
 import os
 import sys
 import inspect
 from collections import OrderedDict
+from collections.abc import Callable
 from pathlib import PurePath
 
 from .cmdparse import CmdOption, TaskParse
@@ -152,7 +152,7 @@ class Task(object):
                   'pos_arg': (string_types, (None,)),
                   'verbosity': ((), (None, 0, 1, 2,)),
                   'getargs': ((dict,), ()),
-                  'title': ((types.FunctionType,), (None,)),
+                  'title': ((Callable,), (None,)),
                   'watch': ((list, tuple), ()),
     }
 

--- a/doit/task.py
+++ b/doit/task.py
@@ -407,7 +407,7 @@ class Task(object):
         @param valid (list): of valid types/value accepted
         @raises InvalidTask if invalid input
         """
-        if isinstance(value, tuple(valid[0])):
+        if isinstance(value, valid[0]):
             return
         if value in valid[1]:
             return

--- a/doit/task.py
+++ b/doit/task.py
@@ -407,8 +407,9 @@ class Task(object):
         @param valid (list): of valid types/value accepted
         @raises InvalidTask if invalid input
         """
-        if type(value) in valid[0]:
-            return
+        for t in valid[0]:
+            if isinstance(value, t):
+                return
         if value in valid[1]:
             return
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -51,21 +51,21 @@ class TestStream():
 class TestTaskCheckInput(object):
 
     def testOkType(self):
-        task.Task.check_attr('xxx', 'attr', [], ([int, list],[]))
+        task.Task.check_attr('xxx', 'attr', [], ((int, list),()))
 
     def testOkTypeABC(self):
-        task.Task.check_attr('xxx', 'attr', {}, ([Iterable],[]))
+        task.Task.check_attr('xxx', 'attr', {}, ((Iterable,),()))
 
     def testOkValue(self):
-        task.Task.check_attr('xxx', 'attr', None, ([list], [None]))
+        task.Task.check_attr('xxx', 'attr', None, ((list,), (None,)))
 
     def testFailType(self):
         pytest.raises(task.InvalidTask, task.Task.check_attr, 'xxx',
-                      'attr', int, ([list], [False]))
+                      'attr', int, ((list,), (False,)))
 
     def testFailValue(self):
         pytest.raises(task.InvalidTask, task.Task.check_attr, 'xxx',
-                      'attr', True, ([list], [False]))
+                      'attr', True, ((list,), (False,)))
 
 
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -3,6 +3,7 @@ import tempfile
 from io import StringIO
 from pathlib import Path, PurePath
 from sys import executable
+from collections.abc import Iterable
 
 import pytest
 
@@ -51,6 +52,9 @@ class TestTaskCheckInput(object):
 
     def testOkType(self):
         task.Task.check_attr('xxx', 'attr', [], ([int, list],[]))
+
+    def testOkTypeABC(self):
+        task.Task.check_attr('xxx', 'attr', {}, ([Iterable],[]))
 
     def testOkValue(self):
         task.Task.check_attr('xxx', 'attr', None, ([list], [None]))


### PR DESCRIPTION
Had to switch to using `isinstance` in `Task.check_attr` to be able to use `collections.abc.Callable`. I think this change makes sense in general and not only to solve #286.

The minimum dodo file provided in #286's description now works (with minor modifications: had to swap `task` and `extra` parameters to `show_cmd`):

```python
#!/usr/bin/env python
# coding: utf-8

import functools

def show_cmd(task, extra):
    return '{}: executing... {}'.format(extra, task.name)

def task_lambda_ok():
    return {
        'actions':['echo lambda'],
        'title': lambda task: show_cmd(task, 'LAMBDA')
    }

def task_partial_ko():
    title = functools.partial(show_cmd, extra='PARTIAL')
    return {
        'actions':['echo partial'],
        'title': title,
    }
```