### PR TITLE
Taskloader API Update

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Changes
  - Add configuration `DOIT_CONFIG` `action_string_formatting` to control command action formatter.
  - Fix `result_dep`, use result **after** its execution
  - Fix #286: Cannot use functools.partial as title
+ - Deprecated TaskLoader in favor of TaskLoader2, which separates loading doit's configuration from loading tasks.
 
 
 0.31.1 (*2018-03-18*)

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -31,10 +31,10 @@ Normally `doit` tasks are defined in a `dodo.py` file.
 This file is loaded, and the list of tasks is created from
 the dict containing task meta-data from the *task-creator* functions.
 
-Subclass TaskLoader to create a custom loader:
+Subclass ``TaskLoader2`` to create a custom loader:
 
-.. autoclass:: doit.cmd_base.TaskLoader
-   :members: load_tasks
+.. autoclass:: doit.cmd_base.TaskLoader2
+   :members:
 
 
 The main program is implemented in the `DoitMain`. It's constructor

--- a/doc/extending.rst
+++ b/doc/extending.rst
@@ -36,6 +36,8 @@ Subclass ``TaskLoader2`` to create a custom loader:
 .. autoclass:: doit.cmd_base.TaskLoader2
    :members:
 
+Before the introduction of ``TaskLoader2`` a now deprecated loader interface ``TaskLoader`` was
+used, which did not separate the setup, configuration loading and task loading phases explicit.
 
 The main program is implemented in the `DoitMain`. It's constructor
 takes an instance of the task loader to be used.

--- a/doc/samples/custom_loader.py
+++ b/doc/samples/custom_loader.py
@@ -3,21 +3,23 @@
 import sys
 
 from doit.task import dict_to_task
-from doit.cmd_base import TaskLoader
+from doit.cmd_base import TaskLoader2
 from doit.doit_cmd import DoitMain
 
 my_builtin_task = {
     'name': 'sample_task',
     'actions': ['echo hello from built in'],
     'doc': 'sample doc',
-    }
+}
 
-class MyLoader(TaskLoader):
-    @staticmethod
-    def load_tasks(cmd, opt_values, pos_args):
+
+class MyLoader(TaskLoader2):
+    def load_doit_config(self):
+        return {'verbosity': 2}
+
+    def load_tasks(self, cmd, pos_args):
         task_list = [dict_to_task(my_builtin_task)]
-        config = {'verbosity': 2}
-        return task_list, config
+        return task_list
 
 
 if __name__ == "__main__":

--- a/doc/samples/custom_loader.py
+++ b/doc/samples/custom_loader.py
@@ -14,6 +14,9 @@ my_builtin_task = {
 
 
 class MyLoader(TaskLoader2):
+    def setup(self, opt_values):
+        pass
+
     def load_doit_config(self):
         return {'verbosity': 2}
 

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -326,10 +326,6 @@ class TaskLoader2(TaskLoaderBase):
     """
     API = 2
 
-    def __init__(self):
-        super().__init__()
-        self.namespace = None
-
     def setup(self, opt_values):
         """Delayed initialization.
 
@@ -345,7 +341,7 @@ class TaskLoader2(TaskLoaderBase):
 
         :return: (dict) Dictionary of doit configuration values.
         """
-        return loader.load_doit_config(self.namespace)
+        raise NotImplementedError()
 
     def load_tasks(self, cmd, pos_args):
         """Load tasks.
@@ -356,10 +352,27 @@ class TaskLoader2(TaskLoaderBase):
         :param pos_args: (list str) positional arguments from command line
         :return: (List[Task])
         """
+        raise NotImplementedError()
+
+
+class NamespaceTaskLoader(TaskLoader2):
+    """Implementation of a loader of tasks from an abstract namespace.
+
+    A namespace is simply a dictionary to objects like functions and objects. See the derived
+    classes for some concrete namespace types.
+    """
+    def __init__(self):
+        super().__init__()
+        self.namespace = None
+
+    def load_doit_config(self):
+        return loader.load_doit_config(self.namespace)
+
+    def load_tasks(self, cmd, pos_args):
         return loader.load_tasks(self.namespace, self.cmd_names, cmd.execute_tasks)
 
 
-class ModuleTaskLoader(TaskLoader2):
+class ModuleTaskLoader(NamespaceTaskLoader):
     """load tasks from a module/dictionary containing task generators
     Usage: `ModuleTaskLoader(my_module)` or `ModuleTaskLoader(globals())`
     """
@@ -371,7 +384,7 @@ class ModuleTaskLoader(TaskLoader2):
             self.namespace = mod_dict
 
 
-class DodoTaskLoader(TaskLoader2):
+class DodoTaskLoader(NamespaceTaskLoader):
     """default task-loader create tasks from a dodo.py file"""
     cmd_options = (opt_dodo, opt_cwd, opt_seek_file)
 

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -292,9 +292,6 @@ class TaskLoader(TaskLoaderBase):
 
     Subclasses must implement the method `load_tasks`. Note: This interface is deprecated, use
     `TaskLoader2` instead.
-
-    :cvar cmd_options:
-          (list of dict) see cmdparse.CmdOption for dict format
     """
     def load_tasks(self, cmd, opt_values, pos_args): # pragma: no cover
         """load tasks and DOIT_CONFIG
@@ -327,6 +324,8 @@ class TaskLoader2(TaskLoaderBase):
     This API update separates the loading of the configuration and the loading of the actual tasks,
     which enables additional elements to be available during task creation.
     """
+    API = 2
+
     def __init__(self):
         super().__init__()
         self.namespace = None
@@ -493,7 +492,7 @@ class DoitCmdBase(Command):
         """
 
         # distinguish legacy and new-style task loader API when loading tasks:
-        legacy_loader = not isinstance(self.loader, TaskLoader2)  # TODO: invert after breaking hierarchy
+        legacy_loader = getattr(self.loader, 'API', 1) < 2
         if legacy_loader:
             self.task_list, dodo_config = self.loader.load_tasks(
                 self, params, args)

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -373,11 +373,11 @@ class DodoTaskLoader(TaskLoader2):
 
     def setup(self, opt_values):
         # lazily load namespace from dodo file per config parameters:
-        self.namespace = loader.get_module(
+        self.namespace = dict(inspect.getmembers(loader.get_module(
             opt_values['dodoFile'],
             opt_values['cwdPath'],
             opt_values['seek_file'],
-        ).__dict__
+        )))
 
 
 def get_loader(config, task_loader=None, cmds=None):

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -341,12 +341,16 @@ class TaskLoader2(TaskLoaderBase):
     def load_doit_config(self):
         """Load doit configuration.
 
+        The method must not be called before invocation of ``setup``.
+
         :return: (dict) Dictionary of doit configuration values.
         """
         return loader.load_doit_config(self.namespace)
 
     def load_tasks(self, cmd, pos_args):
         """Load tasks.
+
+        The method must not be called before invocation of ``load_doit_config``.
 
         :param cmd: (doit.cmd_base.Command) current command being executed
         :param pos_args: (list str) positional arguments from command line

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -332,15 +332,18 @@ class TaskLoader2(TaskLoader):
         """
 
     def load_doit_config(self):
-        """Load doit configuration."""
+        """Load doit configuration.
+
+        :return: (dict) Dictionary of doit configuration values.
+        """
         return loader.load_doit_config(self.namespace)
 
     def load_tasks(self, cmd, pos_args):
         """Load tasks.
 
-        :return: (List[Task])
         :param cmd: (doit.cmd_base.Command) current command being executed
         :param pos_args: (list str) positional arguments from command line
+        :return: (List[Task])
         """
         return loader.load_tasks(self.namespace, self.cmd_names, cmd.execute_tasks)
 
@@ -350,7 +353,7 @@ class ModuleTaskLoader(TaskLoader2):
     Usage: `ModuleTaskLoader(my_module)` or `ModuleTaskLoader(globals())`
     """
     def __init__(self, mod_dict):
-        super(ModuleTaskLoader, self).__init__()
+        super().__init__()
         if inspect.ismodule(mod_dict):
             self.namespace = dict(inspect.getmembers(mod_dict))
         else:
@@ -482,14 +485,13 @@ class DoitCmdBase(Command):
         """
 
         # distinguish legacy and new-style task loader API when loading tasks:
-        if isinstance(self.loader, TaskLoader2):
-            legacy_loader = False
-            self.loader.setup(params)
-            dodo_config = self.loader.load_doit_config()
-        else:
-            legacy_loader = True
+        legacy_loader = not isinstance(self.loader, TaskLoader2)  # TODO: invert after breaking hierarchy
+        if legacy_loader:
             self.task_list, dodo_config = self.loader.load_tasks(
                 self, params, args)
+        else:
+            self.loader.setup(params)
+            dodo_config = self.loader.load_doit_config()
 
         # merge config values from dodo.py into params
         params.update_defaults(dodo_config)

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -341,7 +341,7 @@ class TaskLoader2(TaskLoaderBase):
 
         :return: (dict) Dictionary of doit configuration values.
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     def load_tasks(self, cmd, pos_args):
         """Load tasks.
@@ -352,7 +352,7 @@ class TaskLoader2(TaskLoaderBase):
         :param pos_args: (list str) positional arguments from command line
         :return: (List[Task])
         """
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
 
 class NamespaceTaskLoader(TaskLoader2):

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -272,11 +272,10 @@ opt_seek_file = {
              "[default: %(default)s]")
 }
 
-
 class TaskLoader(object):
     """task-loader interface responsible of creating Task objects
 
-    Subclasses must implement the method `load_tasks`
+    Subclasses must implement the method `load_tasks`.
 
     :cvar cmd_options:
           (list of dict) see cmdparse.CmdOption for dict format
@@ -286,7 +285,7 @@ class TaskLoader(object):
     def __init__(self):
         # list of command names, used to detect clash of task names and commands
         self.cmd_names = []
-        self.config = None # reference to config object taken from Command
+        self.config = None  # reference to config object taken from Command
 
     def load_tasks(self, cmd, opt_values, pos_args): # pragma: no cover
         """load tasks and DOIT_CONFIG
@@ -310,30 +309,64 @@ class TaskLoader(object):
         return task_list, doit_config
 
 
-class ModuleTaskLoader(TaskLoader):
+class TaskLoader2(TaskLoader):
+    """Interface of task loaders with new-style API.
+
+    The default implementation assumes tasks are loaded from a namespace, mapping identifiers to
+    elements like functions (like task generators) or constants (like configuration values).
+
+    This API update separates the loading of the configuration and the loading of the actual tasks,
+    which enables additional elements to be available during task creation.
+    """
+    def __init__(self):
+        super().__init__()
+        self.namespace = None
+
+    def setup(self, opt_values):
+        """Delayed initialization.
+
+        To be implemented if the data is needed by derived classes.
+
+        :param opt_values: (dict) with values for cmd_options
+        """
+
+    def load_doit_config(self):
+        """Load doit configuration."""
+        return loader.load_doit_config(self.namespace)
+
+    def load_tasks(self, cmd, pos_args):
+        """Load tasks.
+
+        :return: (List[Task])
+        :param cmd: (doit.cmd_base.Command) current command being executed
+        :param pos_args: (list str) positional arguments from command line
+        """
+        return loader.load_tasks(self.namespace, self.cmd_names, cmd.execute_tasks)
+
+
+class ModuleTaskLoader(TaskLoader2):
     """load tasks from a module/dictionary containing task generators
     Usage: `ModuleTaskLoader(my_module)` or `ModuleTaskLoader(globals())`
     """
-    cmd_options = ()
-
     def __init__(self, mod_dict):
         super(ModuleTaskLoader, self).__init__()
-        self.mod_dict = mod_dict
+        if inspect.ismodule(mod_dict):
+            self.namespace = dict(inspect.getmembers(mod_dict))
+        else:
+            self.namespace = mod_dict
 
-    def load_tasks(self, cmd, params, args):
-        return self._load_from(cmd, self.mod_dict, self.cmd_names)
 
-
-class DodoTaskLoader(TaskLoader):
+class DodoTaskLoader(TaskLoader2):
     """default task-loader create tasks from a dodo.py file"""
     cmd_options = (opt_dodo, opt_cwd, opt_seek_file)
 
-    def load_tasks(self, cmd, params, args):
-        dodo_module = loader.get_module(
-            params['dodoFile'],
-            params['cwdPath'],
-            params['seek_file'])
-        return self._load_from(cmd, dodo_module, self.cmd_names)
+    def setup(self, opt_values):
+        # lazily load namespace from dodo file per config parameters:
+        self.namespace = loader.get_module(
+            opt_values['dodoFile'],
+            opt_values['cwdPath'],
+            opt_values['seek_file'],
+        ).__dict__
 
 
 def get_loader(config, task_loader=None, cmds=None):
@@ -446,8 +479,17 @@ class DoitCmdBase(Command):
         :param params: instance of cmdparse.DefaultUpdate
         :param args: list of string arguments (containing task names)
         """
-        self.task_list, dodo_config = self.loader.load_tasks(
-            self, params, args)
+
+        # distinguish legacy and new-style task loader API when loading tasks:
+        if isinstance(self.loader, TaskLoader2):
+            new_style_loader = True
+            self.loader.setup(params)
+            dodo_config = self.loader.load_doit_config()
+        else:
+            new_style_loader = False
+            self.task_list, dodo_config = self.loader.load_tasks(
+                self, params, args)
+
         # merge config values from dodo.py into params
         params.update_defaults(dodo_config)
 
@@ -469,6 +511,10 @@ class DoitCmdBase(Command):
             # dep_manager might have been already set (used on unit-test)
             self.dep_manager = Dependency(
                 db_class, params['dep_file'], checker_cls)
+
+        # load tasks from new-style loader, now that dependency manager is available:
+        if new_style_loader:
+            self.task_list = self.loader.load_tasks(cmd=self, pos_args=args)
 
         # hack to pass parameter into _execute() calls that are not part
         # of command line options

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -273,10 +273,8 @@ opt_seek_file = {
 }
 
 
-class TaskLoader(object):
-    """task-loader interface responsible of creating Task objects
-
-    Subclasses must implement the method `load_tasks`
+class TaskLoaderBase:
+    """Common attributes of task loaders.
 
     :cvar cmd_options:
           (list of dict) see cmdparse.CmdOption for dict format
@@ -286,8 +284,18 @@ class TaskLoader(object):
     def __init__(self):
         # list of command names, used to detect clash of task names and commands
         self.cmd_names = []
-        self.config = None # reference to config object taken from Command
+        self.config = None  # reference to config object taken from Command
 
+
+class TaskLoader(TaskLoaderBase):
+    """task-loader interface responsible of creating Task objects
+
+    Subclasses must implement the method `load_tasks`. Note: This interface is deprecated, use
+    `TaskLoader2` instead.
+
+    :cvar cmd_options:
+          (list of dict) see cmdparse.CmdOption for dict format
+    """
     def load_tasks(self, cmd, opt_values, pos_args): # pragma: no cover
         """load tasks and DOIT_CONFIG
 
@@ -310,7 +318,7 @@ class TaskLoader(object):
         return task_list, doit_config
 
 
-class TaskLoader2(TaskLoader):
+class TaskLoader2(TaskLoaderBase):
     """Interface of task loaders with new-style API.
 
     The default implementation assumes tasks are loaded from a namespace, mapping identifiers to

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -272,10 +272,11 @@ opt_seek_file = {
              "[default: %(default)s]")
 }
 
+
 class TaskLoader(object):
     """task-loader interface responsible of creating Task objects
 
-    Subclasses must implement the method `load_tasks`.
+    Subclasses must implement the method `load_tasks`
 
     :cvar cmd_options:
           (list of dict) see cmdparse.CmdOption for dict format
@@ -285,7 +286,7 @@ class TaskLoader(object):
     def __init__(self):
         # list of command names, used to detect clash of task names and commands
         self.cmd_names = []
-        self.config = None  # reference to config object taken from Command
+        self.config = None # reference to config object taken from Command
 
     def load_tasks(self, cmd, opt_values, pos_args): # pragma: no cover
         """load tasks and DOIT_CONFIG
@@ -482,11 +483,11 @@ class DoitCmdBase(Command):
 
         # distinguish legacy and new-style task loader API when loading tasks:
         if isinstance(self.loader, TaskLoader2):
-            new_style_loader = True
+            legacy_loader = False
             self.loader.setup(params)
             dodo_config = self.loader.load_doit_config()
         else:
-            new_style_loader = False
+            legacy_loader = True
             self.task_list, dodo_config = self.loader.load_tasks(
                 self, params, args)
 
@@ -513,7 +514,7 @@ class DoitCmdBase(Command):
                 db_class, params['dep_file'], checker_cls)
 
         # load tasks from new-style loader, now that dependency manager is available:
-        if new_style_loader:
+        if not legacy_loader:
             self.task_list = self.loader.load_tasks(cmd=self, pos_args=args)
 
         # hack to pass parameter into _execute() calls that are not part

--- a/doit/cmd_completion.py
+++ b/doit/cmd_completion.py
@@ -4,7 +4,7 @@ import sys
 from string import Template
 
 from .exceptions import InvalidCommand
-from .cmd_base import DoitCmdBase, TaskLoader2
+from .cmd_base import DoitCmdBase
 
 opt_shell = {
     'name': 'shell',
@@ -97,7 +97,7 @@ class TabCompletion(DoitCmdBase):
 
         # if hardcode tasks
         if opt_values['hardcode_tasks']:
-            if isinstance(self.loader, TaskLoader2):
+            if getattr(self.loader, 'API', 1) == 2:
                 self.loader.setup(opt_values)
                 self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
             else:
@@ -193,7 +193,7 @@ class TabCompletion(DoitCmdBase):
         }
 
         if opt_values['hardcode_tasks']:
-            if isinstance(self.loader, TaskLoader2):
+            if getattr(self.loader, 'API', 1) == 2:
                 self.loader.setup(opt_values)
                 self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
             else:

--- a/doit/cmd_completion.py
+++ b/doit/cmd_completion.py
@@ -99,6 +99,7 @@ class TabCompletion(DoitCmdBase):
         if opt_values['hardcode_tasks']:
             if getattr(self.loader, 'API', 1) == 2:
                 self.loader.setup(opt_values)
+                self.loader.load_doit_config()
                 self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
             else:
                 self.task_list, _ = self.loader.load_tasks(
@@ -195,6 +196,7 @@ class TabCompletion(DoitCmdBase):
         if opt_values['hardcode_tasks']:
             if getattr(self.loader, 'API', 1) == 2:
                 self.loader.setup(opt_values)
+                self.loader.load_doit_config()
                 self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
             else:
                 self.task_list, _ = self.loader.load_tasks(

--- a/doit/cmd_completion.py
+++ b/doit/cmd_completion.py
@@ -4,8 +4,7 @@ import sys
 from string import Template
 
 from .exceptions import InvalidCommand
-from .cmd_base import DoitCmdBase
-
+from .cmd_base import DoitCmdBase, TaskLoader2
 
 opt_shell = {
     'name': 'shell',
@@ -98,8 +97,12 @@ class TabCompletion(DoitCmdBase):
 
         # if hardcode tasks
         if opt_values['hardcode_tasks']:
-            self.task_list, _ = self.loader.load_tasks(
-                self, opt_values, pos_args)
+            if isinstance(self.loader, TaskLoader2):
+                self.loader.setup(opt_values)
+                self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
+            else:
+                self.task_list, _ = self.loader.load_tasks(
+                    self, opt_values, pos_args)
             task_names = (t.name for t in self.task_list if not t.subtask_of)
             tmpl_vars['pt_tasks'] = '"{0}"'.format(' '.join(sorted(task_names)))
         else:
@@ -190,8 +193,12 @@ class TabCompletion(DoitCmdBase):
         }
 
         if opt_values['hardcode_tasks']:
-            self.task_list, _ = self.loader.load_tasks(
-                self, opt_values, pos_args)
+            if isinstance(self.loader, TaskLoader2):
+                self.loader.setup(opt_values)
+                self.task_list = self.loader.load_tasks(cmd=self, pos_args=pos_args)
+            else:
+                self.task_list, _ = self.loader.load_tasks(
+                    self, opt_values, pos_args)
             lines = []
             for task in self.task_list:
                 if not task.subtask_of:

--- a/tests/module_with_tasks.py
+++ b/tests/module_with_tasks.py
@@ -11,4 +11,4 @@ task_no = 'strings are not tasks'
 
 
 def blabla():
-    ...
+    ...  # pragma: no cover

--- a/tests/module_with_tasks.py
+++ b/tests/module_with_tasks.py
@@ -1,0 +1,14 @@
+"""ModuleLoadTest uses this file to load tasks from module."""
+
+DOIT_CONFIG = dict(verbose=2)
+
+
+def task_xxx1():
+    return dict(actions=[])
+
+
+task_no = 'strings are not tasks'
+
+
+def blabla():
+    ...

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -129,6 +129,7 @@ class TestModuleTaskLoader(object):
                    'DOIT_CONFIG': {'verbose': 2},
                    }
         loader = ModuleTaskLoader(members)
+        loader.setup({})
         config = loader.load_doit_config()
         task_list = loader.load_tasks(cmd, [])
         assert ['xxx1'] == [t.name for t in task_list]

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -129,7 +129,8 @@ class TestModuleTaskLoader(object):
                    'DOIT_CONFIG': {'verbose': 2},
                    }
         loader = ModuleTaskLoader(members)
-        task_list, config = loader.load_tasks(cmd, {}, [])
+        config = loader.load_doit_config()
+        task_list = loader.load_tasks(cmd, [])
         assert ['xxx1'] == [t.name for t in task_list]
         assert {'verbose': 2} == config
 
@@ -143,7 +144,9 @@ class TestDodoTaskLoader(object):
                   'seek_file': False,
                   }
         loader = DodoTaskLoader()
-        task_list, config = loader.load_tasks(cmd, params, [])
+        loader.setup(params)
+        config = loader.load_doit_config()
+        task_list = loader.load_tasks(cmd, [])
         assert ['xxx1', 'yyy2'] == [t.name for t in task_list]
         assert {'verbose': 2} == config
 

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -121,7 +121,7 @@ class TestCommand(object):
 
 
 class TestModuleTaskLoader(object):
-    def test_load_tasks(self):
+    def test_load_tasks_from_dict(self):
         cmd = Command()
         members = {'task_xxx1': lambda : {'actions':[]},
                    'task_no': 'strings are not tasks',
@@ -132,6 +132,15 @@ class TestModuleTaskLoader(object):
         loader.setup({})
         config = loader.load_doit_config()
         task_list = loader.load_tasks(cmd, [])
+        assert ['xxx1'] == [t.name for t in task_list]
+        assert {'verbose': 2} == config
+
+    def test_load_tasks_from_module(self):
+        import tests.module_with_tasks as module
+        loader = ModuleTaskLoader(module)
+        loader.setup({})
+        config = loader.load_doit_config()
+        task_list = loader.load_tasks(Command(), [])
         assert ['xxx1'] == [t.name for t in task_list]
         assert {'verbose': 2} == config
 

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -206,6 +206,7 @@ class TestDoitCmdBase(object):
             '--db-file', depfile_name,
             '--mine', 'min'])
 
+
     def test_execute_with_legacy_dict_loader(self, depfile_name):
         members = {'task_xxx1': lambda: {'actions': []}}
 
@@ -219,6 +220,7 @@ class TestDoitCmdBase(object):
             '--mine', 'min',
         ])
 
+
     def test_execute_with_legacy_module_loader(self, depfile_name):
         import tests.module_with_tasks as module
 
@@ -231,6 +233,7 @@ class TestDoitCmdBase(object):
             '--db-file', depfile_name,
             '--mine', 'min',
         ])
+
 
     # command with _execute() method
     def test_minversion(self, depfile_name, monkeypatch):

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -197,16 +197,19 @@ class TestDoitCmdBase(object):
             '--db-file', depfile_name,
             '--mine', 'min'])
 
-    def test_execute_with_legacy_loader(self):
+    def test_execute_with_legacy_loader(self, depfile_name):
 
-        members = {'task_xxx1': lambda : {'actions': []},}
+        members = {'task_xxx1': lambda: {'actions': []}}
 
         class LegacyLoader(TaskLoader):
             def load_tasks(self, cmd, opt_values, pos_args):
                 return super()._load_from(cmd, members, [])
 
         mycmd = self.MyCmd(task_loader=LegacyLoader())
-        assert 'min' == mycmd.parse_execute(['--mine', 'min'])
+        assert 'min' == mycmd.parse_execute([
+            '--db-file', depfile_name,
+            '--mine', 'min',
+        ])
 
     # command with _execute() method
     def test_minversion(self, depfile_name, monkeypatch):

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -206,13 +206,25 @@ class TestDoitCmdBase(object):
             '--db-file', depfile_name,
             '--mine', 'min'])
 
-    def test_execute_with_legacy_loader(self, depfile_name):
-
+    def test_execute_with_legacy_dict_loader(self, depfile_name):
         members = {'task_xxx1': lambda: {'actions': []}}
 
         class LegacyLoader(TaskLoader):
             def load_tasks(self, cmd, opt_values, pos_args):
                 return super()._load_from(cmd, members, [])
+
+        mycmd = self.MyCmd(task_loader=LegacyLoader())
+        assert 'min' == mycmd.parse_execute([
+            '--db-file', depfile_name,
+            '--mine', 'min',
+        ])
+
+    def test_execute_with_legacy_module_loader(self, depfile_name):
+        import tests.module_with_tasks as module
+
+        class LegacyLoader(TaskLoader):
+            def load_tasks(self, cmd, opt_values, pos_args):
+                return super()._load_from(cmd, module, [])
 
         mycmd = self.MyCmd(task_loader=LegacyLoader())
         assert 'min' == mycmd.parse_execute([

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -7,7 +7,7 @@ from doit.cmdparse import CmdParseError, CmdParse
 from doit.exceptions import InvalidCommand, InvalidDodoFile
 from doit.dependency import FileChangedChecker
 from doit.task import Task
-from doit.cmd_base import version_tuple, Command, DoitCmdBase
+from doit.cmd_base import version_tuple, Command, DoitCmdBase, TaskLoader
 from doit.cmd_base import get_loader, ModuleTaskLoader, DodoTaskLoader
 from doit.cmd_base import check_tasks_exist, tasks_and_deps_iter, subtasks_iter
 from .conftest import CmdFactory
@@ -196,6 +196,17 @@ class TestDoitCmdBase(object):
         assert 'min' == mycmd.parse_execute([
             '--db-file', depfile_name,
             '--mine', 'min'])
+
+    def test_execute_with_legacy_loader(self):
+
+        members = {'task_xxx1': lambda : {'actions': []},}
+
+        class LegacyLoader(TaskLoader):
+            def load_tasks(self, cmd, opt_values, pos_args):
+                return super()._load_from(cmd, members, [])
+
+        mycmd = self.MyCmd(task_loader=LegacyLoader())
+        assert 'min' == mycmd.parse_execute(['--mine', 'min'])
 
     # command with _execute() method
     def test_minversion(self, depfile_name, monkeypatch):

--- a/tests/test_cmd_completion.py
+++ b/tests/test_cmd_completion.py
@@ -25,8 +25,7 @@ class FakeLoader(TaskLoader):
 
 class FakeLoader2(TaskLoader2):
     def load_doit_config(self):  # pragma: no cover
-        # not used in tested functionality:
-        raise NotImplementedError()
+        return {}
 
     def load_tasks(self, cmd, pos_args):
         task_list = [

--- a/tests/test_cmd_completion.py
+++ b/tests/test_cmd_completion.py
@@ -25,7 +25,8 @@ class FakeLoader(TaskLoader):
 
 class FakeLoader2(TaskLoader2):
     def load_doit_config(self):
-        return {}
+        # not used in tested functionality:
+        raise NotImplementedError()
 
     def load_tasks(self, cmd, pos_args):
         task_list = [
@@ -50,7 +51,7 @@ def test_invalid_shell_option():
 
 class TestCmdCompletionBash(object):
 
-    def test_with_dodo__dinamic_tasks(self, commands):
+    def test_with_dodo__dynamic_tasks(self, commands):
         output = StringIO()
         cmd = CmdFactory(TabCompletion, task_loader=DodoTaskLoader(),
                          outstream=output, cmds=commands)

--- a/tests/test_cmd_completion.py
+++ b/tests/test_cmd_completion.py
@@ -24,7 +24,7 @@ class FakeLoader(TaskLoader):
 
 
 class FakeLoader2(TaskLoader2):
-    def load_doit_config(self):
+    def load_doit_config(self):  # pragma: no cover
         # not used in tested functionality:
         raise NotImplementedError()
 

--- a/tests/test_cmd_strace.py
+++ b/tests/test_cmd_strace.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from doit.cmd_base import TaskLoader2
 from doit.exceptions import InvalidCommand
 from doit.cmdparse import DefaultUpdate
 from doit.task import Task
@@ -16,12 +17,15 @@ class TestCmdStrace(object):
 
     @staticmethod
     def loader_for_task(task):
-        from doit.cmd_base import TaskLoader2
-        loader = mock.MagicMock(spec_set=TaskLoader2)
-        loader.setup = mock.Mock()
-        loader.load_doit_config = mock.Mock(return_value={})
-        loader.load_tasks = mock.Mock(return_value=[task])
-        return loader
+
+        class MyTaskLoader(TaskLoader2):
+            def load_doit_config(self):
+                return {}
+
+            def load_tasks(self, cmd, pos_args):
+                return [task]
+
+        return MyTaskLoader()
 
     def test_dep(self, dependency1, depfile_name):
         output = StringIO()

--- a/tests/test_cmd_strace.py
+++ b/tests/test_cmd_strace.py
@@ -14,12 +14,20 @@ from .conftest import CmdFactory
     "os.system('strace -V') != 0 or sys.platform in ['win32', 'cygwin']")
 class TestCmdStrace(object):
 
+    @staticmethod
+    def loader_for_task(task):
+        loader = mock.MagicMock()
+        loader.setup = mock.Mock()
+        loader.load_doit_config = mock.Mock(return_value={})
+        loader.load_tasks = mock.Mock(return_value=[task])
+        return loader
+
     def test_dep(self, dependency1, depfile_name):
         output = StringIO()
         task = Task("tt", ["cat %(dependencies)s"],
                     file_dep=['tests/data/dependency1'])
         cmd = CmdFactory(Strace, outstream=output)
-        cmd.loader.load_tasks = mock.Mock(return_value=([task], {}))
+        cmd.loader = self.loader_for_task(task)
         params = DefaultUpdate(dep_file=depfile_name, show_all=False,
                                keep_trace=False, backend='dbm',
                                check_file_uptodate='md5')
@@ -35,7 +43,7 @@ class TestCmdStrace(object):
         task = Task("tt", ["cat %(dependencies)s"],
                     file_dep=['tests/data/dependency1'])
         cmd = CmdFactory(Strace, outstream=output)
-        cmd.loader.load_tasks = mock.Mock(return_value=([task], {}))
+        cmd.loader = self.loader_for_task(task)
         params = DefaultUpdate(dep_file=depfile_name, show_all=True,
                                keep_trace=False, backend='dbm',
                                check_file_uptodate='md5')
@@ -49,7 +57,7 @@ class TestCmdStrace(object):
         task = Task("tt", ["cat %(dependencies)s"],
                     file_dep=['tests/data/dependency1'])
         cmd = CmdFactory(Strace, outstream=output)
-        cmd.loader.load_tasks = mock.Mock(return_value=([task], {}))
+        cmd.loader = self.loader_for_task(task)
         params = DefaultUpdate(dep_file=depfile_name, show_all=True,
                                keep_trace=True, backend='dbm',
                                check_file_uptodate='md5')
@@ -66,7 +74,7 @@ class TestCmdStrace(object):
         task = Task("tt", ["touch %(targets)s"],
                     targets=['tests/data/dependency1'])
         cmd = CmdFactory(Strace, outstream=output)
-        cmd.loader.load_tasks = mock.Mock(return_value=([task], {}))
+        cmd.loader = self.loader_for_task(task)
         params = DefaultUpdate(dep_file=depfile_name, show_all=False,
                                keep_trace=False, backend='dbm',
                                check_file_uptodate='md5')
@@ -83,7 +91,7 @@ class TestCmdStrace(object):
                 ignore
         task = Task("tt", [py_open])
         cmd = CmdFactory(Strace, outstream=output)
-        cmd.loader.load_tasks = mock.Mock(return_value=([task], {}))
+        cmd.loader = self.loader_for_task(task)
         params = DefaultUpdate(dep_file=depfile_name, show_all=False,
                                keep_trace=False, backend='dbm',
                                check_file_uptodate='md5')

--- a/tests/test_cmd_strace.py
+++ b/tests/test_cmd_strace.py
@@ -16,7 +16,8 @@ class TestCmdStrace(object):
 
     @staticmethod
     def loader_for_task(task):
-        loader = mock.MagicMock()
+        from doit.cmd_base import TaskLoader2
+        loader = mock.MagicMock(spec_set=TaskLoader2)
         loader.setup = mock.Mock()
         loader.load_doit_config = mock.Mock(return_value={})
         loader.load_tasks = mock.Mock(return_value=[task])

--- a/tests/test_cmd_strace.py
+++ b/tests/test_cmd_strace.py
@@ -1,6 +1,5 @@
 import os.path
 from io import StringIO
-from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
One way to implement #288 is the ability to access the dependency manager and all values stored by it from task related user-code, including during task generation. This PR is part 1 of that implementation and splits up the existing `task, config = TaskLoader.load_tasks(...)` API into two steps: configuration loading and actual task loading. This enables the dependency manager to be created _before_ task generators are called. The follow up PR will then add the dependency manager access methods.

Some remarks, how this implementation differs from the last pseudo code in #288:

* `ModuleTaskLoader` does not distinguish between dictionary and module in `setup`, but already in `__init__`. This prevents storing the additional attribute `mod_dict` in the instance, which also would be semantically redundant (and possibly a source of inconsistency).