### PR TITLE
fix test warnings

### DIFF
--- a/tests/test_cmd_completion.py
+++ b/tests/test_cmd_completion.py
@@ -87,14 +87,14 @@ class TestCmdCompletionZsh(object):
 
         opt4 = CmdOption({'name':'o4', 'default':'', 'help':'my desc [b]a',
                           'short':'s', 'long':'lll'})
-        assert ('"(-s|--lll)"{-s,--lll}"[my desc [b\]a]" \\' ==
+        assert ('"(-s|--lll)"{-s,--lll}"[my desc [b\\]a]" \\' ==
                 TabCompletion._zsh_arg_line(opt4))
 
         # escaping `"` test
         opt5 = CmdOption({'name':'o5', 'default':'',
                           'help':'''my "des'c [b]a''',
                           'short':'s', 'long':'lll'})
-        assert ('''"(-s|--lll)"{-s,--lll}"[my \\"des'c [b\]a]" \\''' ==
+        assert ('''"(-s|--lll)"{-s,--lll}"[my \\"des'c [b\\]a]" \\''' ==
                 TabCompletion._zsh_arg_line(opt5))
 
 


### PR DESCRIPTION
Unit tests raise these warnings:

```
============================== warnings summary ===============================
tests\test_cmd_completion.py:90
  C:\projects\doit\tests\test_cmd_completion.py:90: DeprecationWarning: invalid escape sequence \]
    assert ('"(-s|--lll)"{-s,--lll}"[my desc [b\]a]" \\' ==
tests\test_cmd_completion.py:97
  C:\projects\doit\tests\test_cmd_completion.py:97: DeprecationWarning: invalid escape sequence \]
    assert ('''"(-s|--lll)"{-s,--lll}"[my \\"des'c [b\]a]" \\''' ==
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

This PR fixes the two invalid escape sequences by replacing `\]` with `\\]`.