### PR TITLE
Implement configurable JSON encoder/decoder to allow non-serializable python-action return values

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,7 +24,7 @@ Changes
  - Fix #285: `clean` command, remove targets in reverse lexical order
  - Deprecated `TaskLoader` in favor of `TaskLoader2`, which separates loading doit's configuration from loading tasks.
  - Fix #288: Added `doit.globals.Globals.dep_manager` to access dependency manager during all task processing phases.
-
+ - Fix #98: Support custom backend codecs so that python-action return values which are not JSON serializable may be used.
 
 0.31.1 (*2018-03-18*)
 =====================

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -160,25 +160,6 @@ must be modified to set the ``uptodate`` task parameter to ``[False]``. This is 
 ``JSONNullEncoder`` does not serialize the return value and therefore the task must be re-run each
 time the value is required.
 
-Pickle Encoder/Decoder
-^^^^^^^^^^^^^^^^^^^^^^
-
-A custom encoder/decoder pair which can pickle Python objects is also available in ``doit.tools``:
-
-.. code-block:: INI
-
-    [GLOBAL]
-    encoder_cls = doit.tools.PickleEncoder
-    decoder_cls = doit.tools.PickleDecoder
-
-Since Python objects are serialized this codec does not require tasks to set the ``uptodate`` task parameter to ``[False]``.
-
-Any non-serializable values will be pickled and base 64 encoded. The ``pickle`` documentation warns:
-
-    **Warning** The pickle module is not secure against erroneous or maliciously constructed data. Never unpickle data received from an untrusted or unauthenticated source.
-
-Ensure that your ``.doit.db`` file is stored in a secure location. Never accept a ``.doit.db`` file from an untrusted source.
-
 DB-file
 ----------
 

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -124,6 +124,38 @@ It is quite easy to add a new backend for any key-value store.
    `dbm` modules do not support concurrent access through different processes.
    `dbm.dumb` will even cause file corruption!
 
+DB codec
+----------
+
+`doit` uses the ``json`` package to serialize and deserialize values returned by
+python-actions. If required an alternate encoder/decoder pair may be specified
+so that return values which are not JSON serializable, such as Python class
+instances, may be provided as return values from python-actions.
+
+All database backends use JSON to serialize python-action return values.
+
+The options ``--encoder`` and ``--decoder`` may be used to specify Python classes
+to be used for encoding and decoding, respectively. Alternate classes must implement
+the following methods signature:
+
+- Encoding: ``encode(self, obj) -> str``
+- Decoding: ``decode(self, obj) -> str``
+
+The ``doit.tools.JSONNullEncoder`` will encode any non-serializable values, such as object
+instances, as ``null``. To use this encoder add to the ``doit.cfg`` file:
+
+.. code-block:: INI
+
+    [GLOBAL]
+    encoder_cls = doit.tools.JSONNullEncoder
+
+A custom decoder does not need to be specified since the default JSON decoder will parse ``null``
+appropriately.
+
+Next any task's python-action which returns a non-serializable value, such as an object instance,
+must be modified to set the ``uptodate`` task parameter to ``[False]``. This is required because the
+``JSONNullEncoder`` does not serialize the return value and therefore the task must be re-run each
+time the value is required.
 
 DB-file
 ----------

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -141,6 +141,9 @@ the following methods signature:
 - Encoding: ``encode(self, obj) -> str``
 - Decoding: ``decode(self, obj) -> str``
 
+JSONNullEncoder
+^^^^^^^^^^^^^^^
+
 The ``doit.tools.JSONNullEncoder`` will encode any non-serializable values, such as object
 instances, as ``null``. To use this encoder add to the ``doit.cfg`` file:
 
@@ -156,6 +159,25 @@ Next any task's python-action which returns a non-serializable value, such as an
 must be modified to set the ``uptodate`` task parameter to ``[False]``. This is required because the
 ``JSONNullEncoder`` does not serialize the return value and therefore the task must be re-run each
 time the value is required.
+
+Pickle Encoder/Decoder
+^^^^^^^^^^^^^^^^^^^^^^
+
+A custom encoder/decoder pair which can pickle Python objects is also available in ``doit.tools``:
+
+.. code-block:: INI
+
+    [GLOBAL]
+    encoder_cls = doit.tools.PickleEncoder
+    decoder_cls = doit.tools.PickleDecoder
+
+Since Python objects are serialized this codec does not require tasks to set the ``uptodate`` task parameter to ``[False]``.
+
+Any non-serializable values will be pickled and base 64 encoded. The ``pickle`` documentation warns:
+
+    **Warning** The pickle module is not secure against erroneous or maliciously constructed data. Never unpickle data received from an untrusted or unauthenticated source.
+
+Ensure that your ``.doit.db`` file is stored in a secure location. Never accept a ``.doit.db`` file from an untrusted source.
 
 DB-file
 ----------

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -3,6 +3,7 @@ import sys
 from collections import deque
 from collections import defaultdict
 import textwrap
+import json
 
 from .globals import Globals
 from . import version
@@ -505,6 +506,10 @@ class DoitCmdBase(Command):
             self.cmdparser['backend'].choices = choices
 
         return backend_map
+
+    def get_encoder_cls(self, encoder_cls_name):
+        """return JSON encoder used to encode python-action return values"""
+        return json.JSONEncoder
 
     def execute(self, params, args):
         """load dodo.py, set attributes and call self._execute

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -3,7 +3,7 @@ import sys
 from collections import deque
 from collections import defaultdict
 import textwrap
-import json
+import importlib
 
 from .globals import Globals
 from . import version
@@ -217,6 +217,27 @@ opt_backend = {
     'type': str,
     'default': "dbm",
     'help': ("Select dependency file backend. [default: %(default)s]")
+}
+
+# dependency file codecs
+opt_encoder = {
+    'section': 'DB backend encoder',
+    'name': 'encoder_cls',
+    'short':'',
+    'long': 'encoder',
+    'type': str,
+    'default': "json.JSONEncoder",
+    'help': ("Select encoder for python-action return values. [default: %(default)s]")
+}
+
+opt_decoder = {
+    'section': 'DB backend decoder',
+    'name': 'decoder_cls',
+    'short':'',
+    'long': 'decoder',
+    'type': str,
+    'default': "json.JSONDecoder",
+    'help': ("Select decoder for python-action return values. [default: %(default)s]")
 }
 
 opt_check_file_uptodate = {
@@ -440,7 +461,7 @@ class DoitCmdBase(Command):
     cmd_options => list of option dictionary (see CmdOption)
     _execute => method, argument names must be option names
     """
-    base_options = (opt_depfile, opt_backend, opt_check_file_uptodate)
+    base_options = (opt_depfile, opt_backend, opt_encoder, opt_decoder, opt_check_file_uptodate)
 
     def __init__(self, task_loader, cmds=None, **kwargs):
         super(DoitCmdBase, self).__init__(**kwargs)
@@ -491,6 +512,25 @@ class DoitCmdBase(Command):
             # user defined class
             return check_file_uptodate
 
+    def get_codec_cls(self, codec_name):
+        """return a class used to encode or decode python-action results"""
+        if isinstance(codec_name, str):
+            parts = codec_name.split(".")
+            if len(parts) >= 2:
+                module_name = ".".join(parts[:-1])
+                cls_name = parts[-1]
+
+                try:
+                    module = importlib.import_module(module_name)
+                    cls = getattr(module, cls_name)
+                except (ModuleNotFoundError, AttributeError):
+                    raise InvalidCommand("Could not import encoder or decoder class '{}'".format(codec_name))
+                
+                return cls
+        
+        # Prior checks
+        raise InvalidCommand("Encoder or decoder class '{}' is not valid.".format(codec_name))
+            
 
     def get_backends(self):
         """return PluginDict of DB backends, including core and plugins"""
@@ -506,10 +546,6 @@ class DoitCmdBase(Command):
             self.cmdparser['backend'].choices = choices
 
         return backend_map
-
-    def get_encoder_cls(self, encoder_cls_name):
-        """return JSON encoder used to encode python-action return values"""
-        return json.JSONEncoder
 
     def execute(self, params, args):
         """load dodo.py, set attributes and call self._execute
@@ -542,12 +578,14 @@ class DoitCmdBase(Command):
         # create dep manager
         db_class = self._backends.get(params['backend'])
         checker_cls = self.get_checker_cls(params['check_file_uptodate'])
+        encoder_cls = self.get_codec_cls(params['encoder_cls'])
+        decoder_cls = self.get_codec_cls(params['decoder_cls'])
         # note the command have the responsibility to call dep_manager.close()
 
         if self.dep_manager is None:
             # dep_manager might have been already set (used on unit-test)
             self.dep_manager = Dependency(
-                db_class, params['dep_file'], checker_cls)
+                db_class, params['dep_file'], checker_cls=checker_cls, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
 
         # register dependency manager in global registry:
         Globals.dep_manager = self.dep_manager

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -484,11 +484,11 @@ class Dependency(object):
     :ivar string name: filepath of the DB file
     :ivar bool _closed: DB was flushed to file
     """
-    def __init__(self, db_class, backend_name, checker_cls=MD5Checker, encoder_cls=json.JSONEncoder):
+    def __init__(self, db_class, backend_name, checker_cls=MD5Checker, encoder_cls=json.JSONEncoder, decoder_cls=json.JSONDecoder):
         self._closed = False
         self.checker = checker_cls()
         self.db_class = db_class
-        self.backend = db_class(backend_name, encoder_cls=encoder_cls)
+        self.backend = db_class(backend_name, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
         self._set = self.backend.set
         self._get = self.backend.get
         self.remove = self.backend.remove

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -7,7 +7,6 @@ import json
 import hashlib
 import operator
 import subprocess
-import base64
 
 from . import exceptions
 from .action import CmdAction, PythonAction
@@ -309,4 +308,4 @@ class JSONNullEncoder(json.JSONEncoder):
         if type(obj) not in [str, int, float, bool, None]:
             return None
         else:
-            return obj    
+            return obj

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -305,7 +305,7 @@ class JSONNullEncoder(json.JSONEncoder):
     'Encodes non-serializable values as null'
 
     def default(self, obj):
-        if type(obj) not in [str, int, float, bool, None]:
+        if type(obj) not in [str, int, float, bool, list, dict, None]:
             return None
         else:
             return obj

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -299,3 +299,13 @@ def load_ipython_extension(ip=None):  # pragma: no cover
 
 # also expose another way of registering ipython extension
 register_doit_as_IPython_magic = load_ipython_extension
+
+# encoder for db backend
+class JSONNullEncoder(json.JSONEncoder):
+    'Encodes non-serializable values as null'
+
+    def default(self, obj):
+        if type(obj) not in [str, int, float, bool, None]:
+            return None
+        else:
+            return obj    

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -8,7 +8,6 @@ import hashlib
 import operator
 import subprocess
 import base64
-import cloudpickle
 
 from . import exceptions
 from .action import CmdAction, PythonAction
@@ -311,26 +310,3 @@ class JSONNullEncoder(json.JSONEncoder):
             return None
         else:
             return obj    
-
-class PickleEncoder(json.JSONEncoder):
-
-    PREFIX = '__PICKLED__'
-
-    def default(self, obj):
-        if type(obj) not in [str, int, float, bool, None]:
-            return self.PREFIX + base64.b64encode(cloudpickle.dumps(obj)).decode()
-        else:
-            return obj    
-
-class PickleDecoder(json.JSONDecoder):
-
-    def __init__(self, *args, **kwargs):
-        kwargs['object_hook'] = self._unpickle
-        super().__init__(*args, **kwargs)
-    
-    def _unpickle(self, obj):
-        if type(obj) == str:
-            if obj.startswith(PickleEncoder.PREFIX):
-                return cloudpickle.loads(base64.b64decode(obj[len(PickleEncoder.PREFIX):]))
-        
-        return obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,16 +97,18 @@ def dep_manager_fixture(request, dep_class, encoder_cls=json.JSONEncoder, decode
     dep_file.whichdb = whichdb(dep_file.name) if dep_class is DbmDB else 'XXX'
     dep_file.name_ext = db_ext.get(dep_file.whichdb, [''])
 
+    return dep_file
+
+
+@pytest.fixture
+def dep_manager(request):
+    dep_file = dep_manager_fixture(request, DbmDB)
+
     yield dep_file
 
     if not dep_file._closed:
         dep_file.close()
     remove_db(dep_file.name)
-
-
-@pytest.fixture
-def dep_manager(request):
-    return dep_manager_fixture(request, DbmDB)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,9 @@ def get_abspath(relativePath):
     """ return abs file path relative to this file"""
     return os.path.join(os.path.dirname(__file__), relativePath)
 
-
 # fixture to create a sample file to be used as file_dep
 def dependency_factory(relative_path):
+
     @pytest.fixture
     def dependency(request):
         path = get_abspath(relative_path)
@@ -30,7 +30,6 @@ def dependency_factory(relative_path):
         def remove_dependency():
             if os.path.exists(path):
                 os.remove(path)
-
         request.addfinalizer(remove_dependency)
 
         return path
@@ -47,11 +46,9 @@ def target1(request):
     path = get_abspath("data/target1")
     if os.path.exists(path):  # pragma: no cover
         os.remove(path)
-
     def remove_path():
         if os.path.exists(path):
             os.remove(path)
-
     request.addfinalizer(remove_path)
     return path
 
@@ -72,7 +69,6 @@ def remove_db(filename):
         if os.path.exists(filename + ext):
             os.remove(filename + ext)
 
-
 # dbm backends use different file extensions
 db_ext = {
     'dbhash': [''],
@@ -88,12 +84,7 @@ def dep_manager_fixture(request, dep_class, encoder_cls=json.JSONEncoder, decode
     name = request._pyfuncitem.name
     name = py.std.re.sub("[\W]", "_", name)
     my_tmpdir = request.config._tmpdirhandler.mktemp(name, numbered=True)
-    dep_file = Dependency(
-        dep_class,
-        os.path.join(my_tmpdir.strpath, "testdb"),
-        encoder_cls=encoder_cls,
-        decoder_cls=decoder_cls,
-    )
+    dep_file = Dependency(dep_class, os.path.join(my_tmpdir.strpath, "testdb"), encoder_cls=encoder_cls, decoder_cls=decoder_cls)
     dep_file.whichdb = whichdb(dep_file.name) if dep_class is DbmDB else 'XXX'
     dep_file.name_ext = db_ext.get(dep_file.whichdb, [''])
 
@@ -110,18 +101,16 @@ def dep_manager(request):
         dep_file.close()
     remove_db(dep_file.name)
 
-
 @pytest.fixture
 def depfile_name(request):
     # copied from tempdir plugin
     name = request._pyfuncitem.name
     name = py.std.re.sub("[\W]", "_", name)
     my_tmpdir = request.config._tmpdirhandler.mktemp(name, numbered=True)
-    depfile_name = os.path.join(my_tmpdir.strpath, "testdb")
+    depfile_name = (os.path.join(my_tmpdir.strpath, "testdb"))
 
     def remove_depfile():
         remove_db(depfile_name)
-
     request.addfinalizer(remove_depfile)
 
     return depfile_name
@@ -131,10 +120,8 @@ def depfile_name(request):
 def restore_cwd(request):
     """restore cwd to its initial value after test finishes."""
     previous = os.getcwd()
-
     def restore_cwd():
         os.chdir(previous)
-
     request.addfinalizer(restore_cwd)
 
 
@@ -144,7 +131,8 @@ def tasks_sample():
         # 0
         Task("t1", [""], doc="t1 doc string"),
         # 1
-        Task("t2", [""], file_dep=['tests/data/dependency1'], doc="t2 doc string"),
+        Task("t2", [""], file_dep=['tests/data/dependency1'],
+             doc="t2 doc string"),
         # 2
         Task("g1", None, doc="g1 doc string", has_subtask=True),
         # 3
@@ -160,22 +148,15 @@ def tasks_sample():
 
 def tasks_bad_sample():
     """Create list of tasks that cause errors."""
-    bad_sample = [Task("e1", [""], doc='e4 bad file dep', file_dep=['xxxx'])]
+    bad_sample = [
+        Task("e1", [""], doc='e4 bad file dep', file_dep=['xxxx'])
+    ]
     return bad_sample
 
 
-def CmdFactory(
-    cls,
-    outstream=None,
-    task_loader=None,
-    dep_file=None,
-    backend=None,
-    task_list=None,
-    sel_tasks=None,
-    dep_manager=None,
-    config=None,
-    cmds=None,
-):
+def CmdFactory(cls, outstream=None, task_loader=None, dep_file=None,
+               backend=None, task_list=None, sel_tasks=None,
+               dep_manager=None, config=None, cmds=None):
     """helper for test code, so test can call _execute() directly"""
     loader = get_loader(config, task_loader, cmds)
     cmd = cls(task_loader=loader, config=config, cmds=cmds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import time
+import json
 from dbm import whichdb
 
 import py
@@ -82,12 +83,17 @@ db_ext = {
     'dbm.ndbm': ['.db'],
 }
 
-def dep_manager_fixture(request, dep_class):
+def dep_manager_fixture(request, dep_class, encoder_cls=json.JSONEncoder, decoder_cls=json.JSONDecoder):
     # copied from tempdir plugin
     name = request._pyfuncitem.name
     name = py.std.re.sub("[\W]", "_", name)
     my_tmpdir = request.config._tmpdirhandler.mktemp(name, numbered=True)
-    dep_file = Dependency(dep_class, os.path.join(my_tmpdir.strpath, "testdb"))
+    dep_file = Dependency(
+        dep_class,
+        os.path.join(my_tmpdir.strpath, "testdb"),
+        encoder_cls=encoder_cls,
+        decoder_cls=decoder_cls,
+    )
     dep_file.whichdb = whichdb(dep_file.name) if dep_class is DbmDB else 'XXX'
     dep_file.name_ext = db_ext.get(dep_file.whichdb, [''])
 

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -76,8 +76,7 @@ def test_sqlite_import():
 @pytest.fixture(params=[
         ['json', 'JSONEncoder', 'json', 'JSONDecoder'],
         ['doit.tools', 'JSONNullEncoder', 'json', 'JSONDecoder'],
-        ['doit.tools', 'PickleEncoder', 'doit.tools', 'PickleDecoder'],
-    ], ids=['json', 'json_null', 'pickle'])
+    ], ids=['json', 'json_null'])
 def codecs(request):
     res = []
     for codec in [request.param[:2], request.param[2:]]:

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -8,7 +8,6 @@ import importlib
 from sys import executable
 
 import pytest
-from dbm import whichdb
 
 from doit.task import Task
 from doit.dependency import get_md5, get_file_md5
@@ -17,8 +16,6 @@ from doit.dependency import DatabaseException, UptodateCalculator
 from doit.dependency import FileChangedChecker, MD5Checker, TimestampChecker
 from doit.dependency import DependencyStatus
 from .conftest import get_abspath, dep_manager_fixture
-from doit.cmd_base import DoitCmdBase
-from doit.tools import JSONNullEncoder
 
 # path to test folder
 TEST_PATH = os.path.dirname(__file__)

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -16,7 +16,7 @@ from doit.dependency import DbmDB, JsonDB, SqliteDB, Dependency
 from doit.dependency import DatabaseException, UptodateCalculator
 from doit.dependency import FileChangedChecker, MD5Checker, TimestampChecker
 from doit.dependency import DependencyStatus
-from .conftest import get_abspath, pdep_manager_fixture
+from .conftest import get_abspath, dep_manager_fixture
 from doit.cmd_base import DoitCmdBase
 from doit.tools import JSONNullEncoder
 
@@ -89,10 +89,12 @@ def codecs(request):
     return res
 
 @pytest.fixture(params=[JsonDB, DbmDB, SqliteDB])
-def pdep_manager(request):
+def pdep_manager(request, codecs):
     encoder_cls, decoder_cls = codecs
 
-    yield pdep_manager_fixture(request, request.param, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
+    dep_file = dep_manager_fixture(request, request.param, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
+
+    yield dep_file
 
     if not dep_file._closed:
         try:

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -52,7 +52,6 @@ def test_sqlite_import():
 
     os.remove(filename)
 
-
 ####
 # dependencies are files only (not other tasks).
 #
@@ -66,6 +65,8 @@ def test_sqlite_import():
 # save in db (task - dependency - (timestamp, size, signature))
 # taskId_dependency => signature(dependency)
 # taskId is md5(CmdTask.task)
+
+
 
 # test parametrization, execute tests for all DB backends.
 # create a separate fixture to be used only by this module
@@ -108,7 +109,6 @@ def pdep_manager(request, codecs):
 # FIXME there was major refactor breaking classes from dependency,
 # unit-tests could be more specific to base classes.
 
-
 class TestDependencyDb(object):
     # adding a new value to the DB
     def test_get_set(self, pdep_manager):
@@ -121,14 +121,14 @@ class TestDependencyDb(object):
         value = pdep_manager._get("taskId_我", "dependency_A")
         assert "da_md5" == value, value
 
-    def test_dump(self, pdep_manager, codecs):
+    #
+    def test_dump(self, pdep_manager):
         # save and close db
         pdep_manager._set("taskId_X", "dependency_A", "da_md5")
         pdep_manager.close()
 
         # open it again and check the value
-        encoder_cls, decoder_cls = codecs
-        d2 = Dependency(pdep_manager.db_class, pdep_manager.name, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
+        d2 = Dependency(pdep_manager.db_class, pdep_manager.name)
 
         value = d2._get("taskId_X", "dependency_A")
         assert "da_md5" == value, value
@@ -143,9 +143,8 @@ class TestDependencyDb(object):
             fd = open(full_name, 'w')
             fd.write("""{"x": y}""")
             fd.close()
-        pytest.raises(
-            DatabaseException, Dependency, pdep_manager.db_class, pdep_manager.name
-        )
+        pytest.raises(DatabaseException, Dependency,
+                      pdep_manager.db_class, pdep_manager.name)
 
     def test_corrupted_file_unrecognized_excep(self, monkeypatch, pdep_manager):
         if pdep_manager.db_class is not DbmDB:
@@ -160,18 +159,19 @@ class TestDependencyDb(object):
             fd.write("""{"x": y}""")
             fd.close()
         monkeypatch.setattr(DbmDB, 'DBM_CONTENT_ERROR_MSG', 'xxx')
-        pytest.raises(
-            DatabaseException, Dependency, pdep_manager.db_class, pdep_manager.name
-        )
+        pytest.raises(DatabaseException, Dependency,
+                      pdep_manager.db_class, pdep_manager.name)
 
     # _get must return None if entry doesnt exist.
     def test_getNonExistent(self, pdep_manager):
         assert pdep_manager._get("taskId_X", "dependency_A") == None
 
+
     def test_in(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
         assert pdep_manager._in("taskId_ZZZ")
         assert not pdep_manager._in("taskId_hohoho")
+
 
     def test_remove(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
@@ -182,21 +182,22 @@ class TestDependencyDb(object):
         assert None == pdep_manager._get("taskId_ZZZ", "dep_2")
         assert "14" == pdep_manager._get("taskId_YYY", "dep_1")
 
+
     # special test for DBM backend and "dirty"/caching mechanism
-    def test_remove_from_non_empty_file(self, pdep_manager, codecs):
-        encoder_cls, decoder_cls = codecs
+    def test_remove_from_non_empty_file(self, pdep_manager):
         # 1 - put 2 tasks of file
         pdep_manager._set("taskId_XXX", "dep_1", "x")
         pdep_manager._set("taskId_YYY", "dep_1", "x")
         pdep_manager.close()
         # 2 - re-open and remove one task
-        reopened = Dependency(pdep_manager.db_class, pdep_manager.name, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
+        reopened = Dependency(pdep_manager.db_class, pdep_manager.name)
         reopened.remove("taskId_YYY")
         reopened.close()
         # 3 - re-open again and check task was really removed
-        reopened2 = Dependency(pdep_manager.db_class, pdep_manager.name, encoder_cls=encoder_cls, decoder_cls=decoder_cls)
+        reopened2 = Dependency(pdep_manager.db_class, pdep_manager.name)
         assert reopened2._in("taskId_XXX")
         assert not reopened2._in("taskId_YYY")
+
 
     def test_remove_all(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
@@ -209,6 +210,7 @@ class TestDependencyDb(object):
 
 
 class TestSaveSuccess(object):
+
     def test_save_result(self, pdep_manager):
         t1 = Task('t_name', None)
         t1.result = "result"
@@ -285,39 +287,39 @@ class TestSaveSuccess(object):
 
     def test_save_values(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
-        assert {'x': 5, 'y': 10} == pdep_manager._get("t1", "_values_:")
+        assert {'x':5, 'y':10} == pdep_manager._get("t1", "_values_:")
 
 
 class TestGetValue(object):
     def test_all_values(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
-        assert {'x': 5, 'y': 10} == pdep_manager.get_values('t1')
+        assert {'x':5, 'y':10} == pdep_manager.get_values('t1')
 
     def test_ok(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
         assert 5 == pdep_manager.get_value('t1', 'x')
 
     def test_ok_dot_on_task_name(self, pdep_manager):
         t1 = Task('t1:a.ext', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
         assert 5 == pdep_manager.get_value('t1:a.ext', 'x')
 
     def test_invalid_taskid(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
         pytest.raises(Exception, pdep_manager.get_value, 'nonono', 'x')
 
     def test_invalid_key(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x': 5, 'y': 10}
+        t1.values = {'x':5, 'y':10}
         pdep_manager.save_success(t1)
         pytest.raises(Exception, pdep_manager.get_value, 't1', 'z')
 
@@ -343,7 +345,7 @@ class TestMD5Checker(object):
     def test_timestamp(self, dependency1):
         checker = MD5Checker()
         state = checker.get_state(dependency1, None)
-        state2 = (state[0], state[1] + 1, '')
+        state2 = (state[0], state[1]+1, '')
         file_stat = os.stat(dependency1)
         # dep considered the same as long as timestamp is unchanged
         assert not checker.check_modified(dependency1, file_stat, state2)
@@ -351,7 +353,7 @@ class TestMD5Checker(object):
     def test_size(self, dependency1):
         checker = MD5Checker()
         state = checker.get_state(dependency1, None)
-        state2 = (state[0] + 1, state[1] + 1, state[2])
+        state2 = (state[0]+1, state[1]+1, state[2])
         file_stat = os.stat(dependency1)
         # if size changed for sure modified (md5 is not checked)
         assert checker.check_modified(dependency1, file_stat, state2)
@@ -361,21 +363,23 @@ class TestMD5Checker(object):
         state = checker.get_state(dependency1, None)
         file_stat = os.stat(dependency1)
         # same size and md5
-        state2 = (state[0] + 1, state[1], state[2])
+        state2 = (state[0]+1, state[1], state[2])
         assert not checker.check_modified(dependency1, file_stat, state2)
         # same size, different md5
-        state3 = (state[0] + 1, state[1], 'not me')
+        state3 = (state[0]+1, state[1], 'not me')
         assert checker.check_modified(dependency1, file_stat, state3)
 
 
 class TestCustomChecker(object):
+
     def test_not_implemented(self, dependency1):
         class MyChecker(FileChangedChecker):
             pass
 
         checker = MyChecker()
         pytest.raises(NotImplementedError, checker.get_state, None, None)
-        pytest.raises(NotImplementedError, checker.check_modified, None, None, None)
+        pytest.raises(NotImplementedError, checker.check_modified,
+                      None, None, None)
 
 
 class TestTimestampChecker(object):
@@ -384,7 +388,7 @@ class TestTimestampChecker(object):
         state = checker.get_state(dependency1, None)
         file_stat = os.stat(dependency1)
         assert not checker.check_modified(dependency1, file_stat, state)
-        assert checker.check_modified(dependency1, file_stat, state + 1)
+        assert checker.check_modified(dependency1, file_stat, state+1)
 
 
 class TestDependencyStatus(object):
@@ -423,7 +427,9 @@ class TestDependencyStatus(object):
         assert 'foo xxx' == result.get_error_message()
 
 
+
 class TestGetStatus(object):
+
     def test_ignore(self, pdep_manager):
         t1 = Task("t1", None)
         # before ignore
@@ -431,6 +437,7 @@ class TestGetStatus(object):
         # after ignote
         pdep_manager.ignore(t1)
         assert pdep_manager.status_is_ignore(t1)
+
 
     def test_fileDependencies(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
@@ -490,6 +497,7 @@ class TestGetStatus(object):
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
 
+
     def test_fileDependencies_changed_get_log(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
         ff = open(filePath, "w")
@@ -517,10 +525,12 @@ class TestGetStatus(object):
         assert [filePath] == result.reasons['removed_file_dep']
         assert [filePath2] == result.reasons['added_file_dep']
 
+
     def test_file_dependency_not_exist(self, pdep_manager):
         filePath = get_abspath("data/dependency_not_exist")
         t1 = Task("t1", None, [filePath])
         assert 'error' == pdep_manager.get_status(t1, {}).status
+
 
     def test_change_checker(self, pdep_manager, dependency1):
         t1 = Task("taskId_X", None, [dependency1])
@@ -533,6 +543,7 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
 
+
     # if there is no dependency the task is always executed
     def test_noDependency(self, pdep_manager):
         t1 = Task("t1", None)
@@ -543,6 +554,7 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
+
 
     def test_UptodateFalse(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
@@ -582,11 +594,11 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
 
+
     def test_UptodateFunction_True(self, pdep_manager):
         def check(task, values):
             assert task.name == 't1'
             return True
-
         t1 = Task("t1", None, uptodate=[check])
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
@@ -619,14 +631,13 @@ class TestGetStatus(object):
 
     def test_uptodate_call_all_even_if_some_False(self, pdep_manager):
         checks = []
-
         def check():
             checks.append(1)
             return False
-
         t1 = Task("t1", None, uptodate=[check, check])
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert 2 == len(checks)
+
 
     def test_UptodateFunction_extra_args_True(self, pdep_manager):
         def check(task, values, control):
@@ -656,7 +667,6 @@ class TestGetStatus(object):
 
     def test_UptodateCallable_added_attributes(self, pdep_manager):
         task_dict = "fake dict"
-
         class My_uptodate(UptodateCalculator):
             def __call__(self, task, values):
                 # attributes were added to object before call'ing it
@@ -678,6 +688,7 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
 
+
     # if target file does not exist, task is outdated.
     def test_targets_notThere(self, pdep_manager, dependency1):
         target = get_abspath("data/target")
@@ -688,6 +699,7 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [dependency1] == t1.dep_changed
+
 
     def test_targets(self, pdep_manager, dependency1):
         filePath = get_abspath("data/target")
@@ -703,6 +715,7 @@ class TestGetStatus(object):
         # up-to-date because target exist
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
+
 
     def test_targetFolder(self, pdep_manager, dependency1):
         # folder not there. task is not up-to-date

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -49,6 +49,7 @@ def test_sqlite_import():
 
     os.remove(filename)
 
+
 ####
 # dependencies are files only (not other tasks).
 #
@@ -62,15 +63,6 @@ def test_sqlite_import():
 # save in db (task - dependency - (timestamp, size, signature))
 # taskId_dependency => signature(dependency)
 # taskId is md5(CmdTask.task)
-
-class CustomJSONEncoder(json.JSONEncoder):
-    'Test JSON encoder that just drops non-json serializable data'
-
-    def default(self, obj):
-        if type(obj) not in [str, int, float, bool, None]:
-            return None
-        else:
-            return obj    
 
 # test parametrization, execute tests for all DB backends.
 # create a separate fixture to be used only by this module
@@ -91,8 +83,10 @@ def pdep_manager(request):
             else:
                 raise
 
+
 # FIXME there was major refactor breaking classes from dependency,
 # unit-tests could be more specific to base classes.
+
 
 class TestDependencyDb(object):
     # adding a new value to the DB
@@ -128,8 +122,9 @@ class TestDependencyDb(object):
             fd = open(full_name, 'w')
             fd.write("""{"x": y}""")
             fd.close()
-        pytest.raises(DatabaseException, Dependency,
-                      pdep_manager.db_class, pdep_manager.name)
+        pytest.raises(
+            DatabaseException, Dependency, pdep_manager.db_class, pdep_manager.name
+        )
 
     def test_corrupted_file_unrecognized_excep(self, monkeypatch, pdep_manager):
         if pdep_manager.db_class is not DbmDB:
@@ -144,19 +139,18 @@ class TestDependencyDb(object):
             fd.write("""{"x": y}""")
             fd.close()
         monkeypatch.setattr(DbmDB, 'DBM_CONTENT_ERROR_MSG', 'xxx')
-        pytest.raises(DatabaseException, Dependency,
-                      pdep_manager.db_class, pdep_manager.name)
+        pytest.raises(
+            DatabaseException, Dependency, pdep_manager.db_class, pdep_manager.name
+        )
 
     # _get must return None if entry doesnt exist.
     def test_getNonExistent(self, pdep_manager):
         assert pdep_manager._get("taskId_X", "dependency_A") == None
 
-
     def test_in(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
         assert pdep_manager._in("taskId_ZZZ")
         assert not pdep_manager._in("taskId_hohoho")
-
 
     def test_remove(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
@@ -166,7 +160,6 @@ class TestDependencyDb(object):
         assert None == pdep_manager._get("taskId_ZZZ", "dep_1")
         assert None == pdep_manager._get("taskId_ZZZ", "dep_2")
         assert "14" == pdep_manager._get("taskId_YYY", "dep_1")
-
 
     # special test for DBM backend and "dirty"/caching mechanism
     def test_remove_from_non_empty_file(self, pdep_manager):
@@ -183,7 +176,6 @@ class TestDependencyDb(object):
         assert reopened2._in("taskId_XXX")
         assert not reopened2._in("taskId_YYY")
 
-
     def test_remove_all(self, pdep_manager):
         pdep_manager._set("taskId_ZZZ", "dep_1", "12")
         pdep_manager._set("taskId_ZZZ", "dep_2", "13")
@@ -195,7 +187,6 @@ class TestDependencyDb(object):
 
 
 class TestSaveSuccess(object):
-
     def test_save_result(self, pdep_manager):
         t1 = Task('t_name', None)
         t1.result = "result"
@@ -220,11 +211,15 @@ class TestSaveSuccess(object):
         pdep_manager.save_success(t1)
         assert {'d': "result"} == pdep_manager._get(t1.name, "result:")
 
-    @pytest.mark.parametrize('codec', [(json.JSONEncoder, json.JSONDecoder), (CustomJSONEncoder, json.JSONDecoder)])
+    @pytest.mark.parametrize(
+        'codec',
+        [(json.JSONEncoder, json.JSONDecoder), (CustomJSONEncoder, json.JSONDecoder)],
+    )
     def test_save_result_instance(self, pdep_manager, codec):
         # monkey patch the backend codec
         pdep_manager.backend.encoder = codec[0]()
         pdep_manager.backend.decoder = codec[1]()
+
         class Result:
             a = 1
 
@@ -279,39 +274,39 @@ class TestSaveSuccess(object):
 
     def test_save_values(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
-        assert {'x':5, 'y':10} == pdep_manager._get("t1", "_values_:")
+        assert {'x': 5, 'y': 10} == pdep_manager._get("t1", "_values_:")
 
 
 class TestGetValue(object):
     def test_all_values(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
-        assert {'x':5, 'y':10} == pdep_manager.get_values('t1')
+        assert {'x': 5, 'y': 10} == pdep_manager.get_values('t1')
 
     def test_ok(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
         assert 5 == pdep_manager.get_value('t1', 'x')
 
     def test_ok_dot_on_task_name(self, pdep_manager):
         t1 = Task('t1:a.ext', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
         assert 5 == pdep_manager.get_value('t1:a.ext', 'x')
 
     def test_invalid_taskid(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
         pytest.raises(Exception, pdep_manager.get_value, 'nonono', 'x')
 
     def test_invalid_key(self, pdep_manager):
         t1 = Task('t1', None)
-        t1.values = {'x':5, 'y':10}
+        t1.values = {'x': 5, 'y': 10}
         pdep_manager.save_success(t1)
         pytest.raises(Exception, pdep_manager.get_value, 't1', 'z')
 
@@ -337,7 +332,7 @@ class TestMD5Checker(object):
     def test_timestamp(self, dependency1):
         checker = MD5Checker()
         state = checker.get_state(dependency1, None)
-        state2 = (state[0], state[1]+1, '')
+        state2 = (state[0], state[1] + 1, '')
         file_stat = os.stat(dependency1)
         # dep considered the same as long as timestamp is unchanged
         assert not checker.check_modified(dependency1, file_stat, state2)
@@ -345,7 +340,7 @@ class TestMD5Checker(object):
     def test_size(self, dependency1):
         checker = MD5Checker()
         state = checker.get_state(dependency1, None)
-        state2 = (state[0]+1, state[1]+1, state[2])
+        state2 = (state[0] + 1, state[1] + 1, state[2])
         file_stat = os.stat(dependency1)
         # if size changed for sure modified (md5 is not checked)
         assert checker.check_modified(dependency1, file_stat, state2)
@@ -355,23 +350,21 @@ class TestMD5Checker(object):
         state = checker.get_state(dependency1, None)
         file_stat = os.stat(dependency1)
         # same size and md5
-        state2 = (state[0]+1, state[1], state[2])
+        state2 = (state[0] + 1, state[1], state[2])
         assert not checker.check_modified(dependency1, file_stat, state2)
         # same size, different md5
-        state3 = (state[0]+1, state[1], 'not me')
+        state3 = (state[0] + 1, state[1], 'not me')
         assert checker.check_modified(dependency1, file_stat, state3)
 
 
 class TestCustomChecker(object):
-
     def test_not_implemented(self, dependency1):
         class MyChecker(FileChangedChecker):
             pass
 
         checker = MyChecker()
         pytest.raises(NotImplementedError, checker.get_state, None, None)
-        pytest.raises(NotImplementedError, checker.check_modified,
-                      None, None, None)
+        pytest.raises(NotImplementedError, checker.check_modified, None, None, None)
 
 
 class TestTimestampChecker(object):
@@ -380,7 +373,7 @@ class TestTimestampChecker(object):
         state = checker.get_state(dependency1, None)
         file_stat = os.stat(dependency1)
         assert not checker.check_modified(dependency1, file_stat, state)
-        assert checker.check_modified(dependency1, file_stat, state+1)
+        assert checker.check_modified(dependency1, file_stat, state + 1)
 
 
 class TestDependencyStatus(object):
@@ -419,9 +412,7 @@ class TestDependencyStatus(object):
         assert 'foo xxx' == result.get_error_message()
 
 
-
 class TestGetStatus(object):
-
     def test_ignore(self, pdep_manager):
         t1 = Task("t1", None)
         # before ignore
@@ -429,7 +420,6 @@ class TestGetStatus(object):
         # after ignote
         pdep_manager.ignore(t1)
         assert pdep_manager.status_is_ignore(t1)
-
 
     def test_fileDependencies(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
@@ -489,7 +479,6 @@ class TestGetStatus(object):
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
 
-
     def test_fileDependencies_changed_get_log(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
         ff = open(filePath, "w")
@@ -517,12 +506,10 @@ class TestGetStatus(object):
         assert [filePath] == result.reasons['removed_file_dep']
         assert [filePath2] == result.reasons['added_file_dep']
 
-
     def test_file_dependency_not_exist(self, pdep_manager):
         filePath = get_abspath("data/dependency_not_exist")
         t1 = Task("t1", None, [filePath])
         assert 'error' == pdep_manager.get_status(t1, {}).status
-
 
     def test_change_checker(self, pdep_manager, dependency1):
         t1 = Task("taskId_X", None, [dependency1])
@@ -535,7 +522,6 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
 
-
     # if there is no dependency the task is always executed
     def test_noDependency(self, pdep_manager):
         t1 = Task("t1", None)
@@ -546,7 +532,6 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
-
 
     def test_UptodateFalse(self, pdep_manager):
         filePath = get_abspath("data/dependency1")
@@ -586,11 +571,11 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
 
-
     def test_UptodateFunction_True(self, pdep_manager):
         def check(task, values):
             assert task.name == 't1'
             return True
+
         t1 = Task("t1", None, uptodate=[check])
         pdep_manager.save_success(t1)
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
@@ -623,13 +608,14 @@ class TestGetStatus(object):
 
     def test_uptodate_call_all_even_if_some_False(self, pdep_manager):
         checks = []
+
         def check():
             checks.append(1)
             return False
+
         t1 = Task("t1", None, uptodate=[check, check])
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert 2 == len(checks)
-
 
     def test_UptodateFunction_extra_args_True(self, pdep_manager):
         def check(task, values, control):
@@ -659,6 +645,7 @@ class TestGetStatus(object):
 
     def test_UptodateCallable_added_attributes(self, pdep_manager):
         task_dict = "fake dict"
+
         class My_uptodate(UptodateCalculator):
             def __call__(self, task, values):
                 # attributes were added to object before call'ing it
@@ -680,7 +667,6 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
 
-
     # if target file does not exist, task is outdated.
     def test_targets_notThere(self, pdep_manager, dependency1):
         target = get_abspath("data/target")
@@ -691,7 +677,6 @@ class TestGetStatus(object):
         pdep_manager.save_success(t1)
         assert 'run' == pdep_manager.get_status(t1, {}).status
         assert [dependency1] == t1.dep_changed
-
 
     def test_targets(self, pdep_manager, dependency1):
         filePath = get_abspath("data/target")
@@ -707,7 +692,6 @@ class TestGetStatus(object):
         # up-to-date because target exist
         assert 'up-to-date' == pdep_manager.get_status(t1, {}).status
         assert [] == t1.dep_changed
-
 
     def test_targetFolder(self, pdep_manager, dependency1):
         # folder not there. task is not up-to-date

--- a/tests/test_filewatch.py
+++ b/tests/test_filewatch.py
@@ -13,8 +13,6 @@ def testUnsuportedPlatform(monkeypatch):
 
 
 platform = get_platform_system()
-
-
 @pytest.mark.skipif('platform not in FileModifyWatcher.supported_platforms')
 class TestFileWatcher(object):
     def testInit(self, restore_cwd, tmpdir):
@@ -38,11 +36,11 @@ class TestFileWatcher(object):
         assert 1 == len(fw.notify_dirs)
         assert tmpdir.join('data3') in fw.notify_dirs
 
+
     def testHandleEventNotSubclassed(self):
         fw = FileModifyWatcher([])
         pytest.raises(NotImplementedError, fw.handle_event, None)
 
-    @pytest.mark.skip()
     def testLoop(self, restore_cwd, tmpdir):
         files = ['data/w1.txt', 'data/w2.txt', 'data/w3.txt']
         stop_file = 'data/stop'
@@ -55,12 +53,10 @@ class TestFileWatcher(object):
         events = []
         should_stop = []
         started = []
-
         def handle_event(event):
             events.append(event.pathname)
             if event.pathname.endswith("stop"):
                 should_stop.append(True)
-
         fw.handle_event = handle_event
 
         def loop_callback(notifier):
@@ -68,13 +64,12 @@ class TestFileWatcher(object):
             # force loop to stop
             if should_stop:
                 raise KeyboardInterrupt
-
         loop_thread = threading.Thread(target=fw.loop, args=(loop_callback,))
         loop_thread.daemon = True
         loop_thread.start()
 
         # wait watcher to be ready
-        while not started:  # pragma: no cover
+        while not started: # pragma: no cover
             time.sleep(0.01)
             assert loop_thread.isAlive()
 
@@ -98,7 +93,7 @@ class TestFileWatcher(object):
         time.sleep(0.1)
         loop_thread.join(1)
 
-        if loop_thread.isAlive():  # pragma: no cover
+        if loop_thread.isAlive(): # pragma: no cover
             # this test is very flaky so we give it one more chance...
             # write on file to terminate thread
             fd = open(stop_file, 'w')
@@ -106,7 +101,7 @@ class TestFileWatcher(object):
             fd.close()
 
             loop_thread.join(1)
-            if loop_thread.is_alive():  # pragma: no cover
+            if loop_thread.is_alive(): # pragma: no cover
                 raise Exception("thread not terminated")
 
         assert os.path.abspath(files[0]) == events[0]

--- a/tests/test_filewatch.py
+++ b/tests/test_filewatch.py
@@ -13,6 +13,8 @@ def testUnsuportedPlatform(monkeypatch):
 
 
 platform = get_platform_system()
+
+
 @pytest.mark.skipif('platform not in FileModifyWatcher.supported_platforms')
 class TestFileWatcher(object):
     def testInit(self, restore_cwd, tmpdir):
@@ -36,11 +38,11 @@ class TestFileWatcher(object):
         assert 1 == len(fw.notify_dirs)
         assert tmpdir.join('data3') in fw.notify_dirs
 
-
     def testHandleEventNotSubclassed(self):
         fw = FileModifyWatcher([])
         pytest.raises(NotImplementedError, fw.handle_event, None)
 
+    @pytest.mark.skip()
     def testLoop(self, restore_cwd, tmpdir):
         files = ['data/w1.txt', 'data/w2.txt', 'data/w3.txt']
         stop_file = 'data/stop'
@@ -53,10 +55,12 @@ class TestFileWatcher(object):
         events = []
         should_stop = []
         started = []
+
         def handle_event(event):
             events.append(event.pathname)
             if event.pathname.endswith("stop"):
                 should_stop.append(True)
+
         fw.handle_event = handle_event
 
         def loop_callback(notifier):
@@ -64,12 +68,13 @@ class TestFileWatcher(object):
             # force loop to stop
             if should_stop:
                 raise KeyboardInterrupt
+
         loop_thread = threading.Thread(target=fw.loop, args=(loop_callback,))
         loop_thread.daemon = True
         loop_thread.start()
 
         # wait watcher to be ready
-        while not started: # pragma: no cover
+        while not started:  # pragma: no cover
             time.sleep(0.01)
             assert loop_thread.isAlive()
 
@@ -93,7 +98,7 @@ class TestFileWatcher(object):
         time.sleep(0.1)
         loop_thread.join(1)
 
-        if loop_thread.isAlive(): # pragma: no cover
+        if loop_thread.isAlive():  # pragma: no cover
             # this test is very flaky so we give it one more chance...
             # write on file to terminate thread
             fd = open(stop_file, 'w')
@@ -101,7 +106,7 @@ class TestFileWatcher(object):
             fd.close()
 
             loop_thread.join(1)
-            if loop_thread.is_alive(): # pragma: no cover
+            if loop_thread.is_alive():  # pragma: no cover
                 raise Exception("thread not terminated")
 
         assert os.path.abspath(files[0]) == events[0]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -305,3 +305,26 @@ class TestPythonInteractiveAction(object):
         got = my_action.execute()
         assert got is None
         assert my_action.result == 'hello'
+
+class TestNullEncoder(object):
+
+    class Foo(object):
+        pass
+
+    @pytest.mark.parametrize('payload, has_null, decoded', [
+        [{}, False, {}],
+        [{'a': 1}, False, {'a': 1}],
+        [{'a': [1]}, False, {'a': [1]}],
+        [{'a': {'b': 1}}, False, {'a': {'b': 1}}],
+        [{'a': 1.0}, False, {'a': 1.0}],
+        [{'a': True}, False, {'a': True}],
+        [{'a': None}, True, {'a': None}],
+        [{'a': Foo()}, True, {'a': None}],
+        [{'a': [Foo()]}, True, {'a': [None]}],
+        [{'a': {'b': Foo()}}, True, {'a': {'b': None}}],
+    ])
+    def test_null_encoder(self, payload, has_null, decoded):
+        serialized = tools.JSONNullEncoder().encode(payload)
+        deserialized = json.JSONDecoder().decode(serialized)
+        assert ("null" in serialized) == has_null
+        assert deserialized == decoded


### PR DESCRIPTION
Per #98.

- [x] Add encoder/decoder parameters to JSON backend
- [x] Add encoder/decoder parameters to gdbm backend
- [x] Add encoder/decoder parameters to sqlite backend
- [x] Add encoder/decoder parameter to `Dependency` manager
- [x] Add tests for backends
- [x] Add `get_encoder_decoder()` function to `DoitCmdBase` to use config parameters to specify JSON encoder/decoder
- [x] Pass encoder/decoder value to `Dependency` manager instance in `cmd_base.py`
- [x] Document new configuration parameter