### PR TITLE
[minor] Docs: call attn to custom doc (besides docstring)

### DIFF
--- a/doc/samples/task_reusable.py
+++ b/doc/samples/task_reusable.py
@@ -1,9 +1,11 @@
 
 def gen_many_tasks():
+    """ first line of docstring becomes doc kwarg """
     yield {'basename': 't1',
            'actions': ['echo t1']}
     yield {'basename': 't2',
-           'actions': ['echo t2']}
+           'actions': ['echo t2'],
+           'doc': "t2 override of doc kwarg"}
 
 def task_all():
     yield gen_many_tasks()


### PR DESCRIPTION
* Seeing that I could customize the `doc` attribute of a task, I realized I actually like subtasks. (Before I had found them confusing as it seemed like I had to choose between all-tasks docstring or nothing.)
* Might make sense to call this out to readers early on.

----

I figure this is not the only doc file to update, if the change is to be accepted... Let me know?