### PR TITLE
Bind delayed task creating functions to the object instance.

### DIFF
--- a/doit/loader.py
+++ b/doit/loader.py
@@ -136,7 +136,15 @@ def load_tasks(namespace, command_names=(), allow_delayed=False):
     task_list = []
     def _process_gen():
         task_list.extend(generate_tasks(name, ref(), ref.__doc__))
-    def _add_delayed(tname):
+    def _add_delayed(tname, ref):
+        # If ref is a bound method this updates the DelayedLoader specification
+        # so that when delayed.creator is executed later (control.py:469) the
+        # self parameter is provided. control.py:469 may execute this function
+        # with any additional parameters.
+        #
+        # If ref is NOT a method this this line simply re-assigns the
+        # same function.
+        delayed.creator = ref
         task_list.append(Task(tname, None, loader=delayed,
                               doc=delayed.creator.__doc__))
 
@@ -147,9 +155,9 @@ def load_tasks(namespace, command_names=(), allow_delayed=False):
             _process_gen()
         elif delayed.creates:  # delayed with explicit task basename
             for tname in delayed.creates:
-                _add_delayed(tname)
+                _add_delayed(tname, ref)
         elif allow_delayed:  # delayed no explicit name, cmd run
-            _add_delayed(name)
+            _add_delayed(name, ref)
         else:  # delayed no explicit name, cmd list (run creator)
             _process_gen()
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -131,6 +131,38 @@ class TestLoadTasks(object):
         assert tasks['bar'].loader is tasks['foo'].loader
         assert tasks['foo'].doc == 'not loaded task doc'
 
+    def testClassCreateAfterDecorator(self):
+        'Check that class-defined tasks are loaded as bound methods'
+        class Tasks:
+            @create_after('yyy2')
+            def task_zzz3(): # pragma: no cover
+                pass
+
+        # create_after annotates the function
+        task_list = load_tasks({'task_zzz3': Tasks().task_zzz3}, allow_delayed=True)
+        tasks = {t.name:t for t in task_list}
+        task_zzz3 = tasks['zzz3']
+        assert isinstance(task_zzz3.loader, DelayedLoader)
+        assert getattr(task_zzz3.loader.creator, '__self__', None) is not None, 'Class-defined delayed task creating method is not bound'
+
+    def testClassInitialLoadDelayedTask_creates(self, dodo):
+        'Check that class-defined tasks support the creates argument of @create_after'       
+        class Tasks:
+            @create_after('yyy2', creates=['foo', 'bar'])
+            def task_zzz3(): # pragma: no cover
+                '''not loaded task doc'''
+                raise Exception('Cant be executed on load phase')
+
+        # placeholder task is created with `loader` attribute
+        task_list = load_tasks({'task_zzz3': Tasks().task_zzz3}, allow_delayed=True)
+        tasks = {t.name:t for t in task_list}
+        assert 'zzz3' not in tasks
+        f_task = tasks['foo']
+        assert f_task.loader.task_dep == 'yyy2'
+        assert getattr(f_task.loader.creator, '__self__', None) is not None, 'Class-defined delayed task creating method is not bound'
+        assert tasks['bar'].loader is tasks['foo'].loader
+        assert tasks['foo'].doc == 'not loaded task doc'
+
     def testNameInBlacklist(self):
         dodo_module = {'task_cmd_name': lambda:None}
         pytest.raises(InvalidDodoFile, load_tasks, dodo_module, ['cmd_name'])


### PR DESCRIPTION
I tried to use `@create_after` with task definitions created from class methods and it didn't work. I thought this would work because nothing in the documentation implies that it doesn't. I dug into this and it seems to be a simple fix.

The @create_after decorator stashes a reference to the unbound method in a DelayedLoader instance. To work with tasks defined by methods the reference must be bound to the task creating class instance.

Please let me know if you have any comments or suggested improvements.

Simple Example:

```python
#!/usr/bin/env python3
import sys
import glob

from doit.cmd_base import ModuleTaskLoader
from doit.doit_cmd import DoitMain
from doit import create_after
from doit.task import DelayedLoader

class SomeTasks:

    @create_after(executed='early', target_regex='.*\.out')
    def task_build(self):
        for inf in glob.glob('*.in'):
            yield {
                'name': inf,
                'actions': ['cp %(dependencies)s %(targets)s'],
                'file_dep': [inf],
                'targets': [inf[:-3] + '.out'],
                'clean': True,
            }

    def task_early(self):
        """a task that create some files..."""
        inter_files = ('a.in', 'b.in', 'c.in')
        return {
            'actions': ['touch %(targets)s'],
            'targets': inter_files,
            'clean': True,
        }

if __name__ == "__main__":
    obj = SomeTasks()
    task_methods = {key: getattr(obj, key) for key in dir(obj) if key.startswith('task_')}
    loader = ModuleTaskLoader(task_methods)
    sys.exit(DoitMain(loader).run(sys.argv[1:]))
```