### PR TITLE
Specifying options (params) for subtasks

### DIFF
--- a/doit/loader.py
+++ b/doit/loader.py
@@ -49,8 +49,9 @@ def flat_generator(gen, gen_doc=''):
                                             "return statement (to customize a"
                                             " group Task).")
                         else:
-                            # generate a new StopIteration by returning None
-                            return
+                            # break from this loop as this generator has nothing more
+                            # to provide
+                            break
                     else:
                         yield value, value_doc
             else:
@@ -334,6 +335,7 @@ def _generate_tasks_from_generator(func_name, gen_result, gen_doc):
                     group_task = tasks.get(func_name)
 
                     # override contents
+                    # TODO maybe move part of this code into a task.update() method for consistency
                     for k, v in extra_info.items():
                         # TODO should we support overriding other items?
                         if k in ('params',):

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -43,7 +43,7 @@ def flat_generator(gen, gen_doc=''):
                         # make sure that the user did not make a mistake by
                         # using return in the wrong place
                         if e.value is not None:
-                            raise Exception("Invalid `return` statement in"
+                            raise Exception("Invalid `return` statement in "
                                             "nested generator. Only root-level"
                                             "generators can include a non-None"
                                             "return statement (to customize a"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@ import os
 import inspect
 
 import pytest
+from doit.control import TaskControl
 
 from doit.exceptions import InvalidDodoFile, InvalidCommand
 from doit.task import InvalidTask, DelayedLoader, Task
@@ -248,6 +249,18 @@ class TestGenerateTasksGenerator(object):
         assert "xpto:0" == tasks[0].task_dep[0]
         assert "xpto:0" == tasks[1].name
         assert tasks[1].subtask_of == 'xpto'
+
+    def testGeneratorWithParams(self):
+        def f_xpto():
+            for i in range(3):
+                yield {'name': str(i),
+                       'actions': ["{cmd_name} -%d"%i]}
+            return {'params': [{'name': 'cmd_name', 'short': 'n', 'long': 'cmd_name', 'default': None}]}
+        tasks = generate_tasks("xpto", f_xpto())
+        options = ["xpto:0", "--cmd_name", "xpto"]
+        tc = TaskControl(tasks)
+        assert ['xpto:0'] == tc._filter_tasks(options)
+        assert "xpto" == tc.tasks['xpto:0'].options['cmd_name']
 
     def testMultiLevelGenerator(self):
         def f_xpto(base_name):


### PR DESCRIPTION
A step towards #311  .

I managed to make my propoal work: i.e. a return statement after the generator in a group task will modify the params on the group task AND the ones in the subtasks.

So you can for example write:

```python
from doit.tools import title_with_actions

def task_mytask():
    yield {
            'name': 'mysubtask',
            'actions': ["echo myparam is %(myparam)s"],
            'title': title_with_actions,
            'verbosity': 2,
        }

    # new: the final return statement defines params
    # for the group task AND all yielded subtasks
    return {'params': [{'name': 'myparam',
                        'long': 'myparam',
                        'default': None}]}

```

Currently it only works if the parameter is passed to a **named** subtask through the CLI: for example `doit mytask:mysubtask --myparam hello` will give

```
.  mytask:mysubtask => Cmd: echo myparam is %(myparam)s
myparam is hello
```

(By the way the title is not updated, this is maybe another issue.)

However the parameter is not correctly propagated if I call the group task instead `doit mytask --myparam hello` yields

```
.  mytask:mysubtask => Cmd: echo myparam is %(myparam)s
myparam is None
```

Any idea why ?

I can not figure out from the documentation how to propagate a parameter from the CLI or from the configuration file to a task without naming the task (and in this case the subtask) explicitly. Any help would be appreciated so that I can finalize the proposal.

The PR still misses unit tests and conceptual validation of what is been done: as of now I copy the group task params to all subtasks.


Thanks!
