### PR TITLE
Add feature to specify task parameters in doit.cfg (issue #283)

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -68,6 +68,17 @@ Check the :ref:`plugins <plugins>` section for an introduction
 on available plugin categories.
 
 
+per-task sections
+^^^^^^^^^^^^^^^^^
+
+To configure options for a specific task, use a section with
+the task name prefixed with "task:"::
+
+ [task:make_cookies]
+ cookie_type = chocolate
+ temp = 375F
+ duration = 12
+
 configuration at *dodo.py*
 --------------------------
 

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -388,10 +388,11 @@ class NamespaceTaskLoader(TaskLoader2):
                                  cmd.execute_tasks)
 
         # Add task options from config, if present
-        for task in tasks:
-            task_stanza = 'task:' + task.name
-            if task_stanza in self.config:
-                task.cfg_values = self.config[task_stanza]
+        if self.config is not None:
+            for task in tasks:
+                task_stanza = 'task:' + task.name
+                if task_stanza in self.config:
+                    task.cfg_values = self.config[task_stanza]
 
         return tasks
 

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -384,9 +384,16 @@ class NamespaceTaskLoader(TaskLoader2):
         return loader.load_doit_config(self.namespace)
 
     def load_tasks(self, cmd, pos_args):
-        return loader.load_tasks(self.namespace, self.cmd_names,
+        tasks = loader.load_tasks(self.namespace, self.cmd_names,
                                  cmd.execute_tasks)
 
+        # Add task options from config, if present
+        for task in tasks:
+            task_stanza = 'task:' + task.name
+            if task_stanza in self.config:
+                task.cfg_values = self.config[task_stanza]
+
+        return tasks
 
 class ModuleTaskLoader(NamespaceTaskLoader):
     """load tasks from a module/dictionary containing task generators
@@ -577,12 +584,6 @@ class DoitCmdBase(Command):
         # load tasks from new-style loader
         if not legacy_loader:
             self.task_list = self.loader.load_tasks(cmd=self, pos_args=args)
-
-        # Add task options from config, if present
-        for task in self.task_list:
-            task_stanza = 'task:' + task.name
-            if task_stanza in self.config:
-                task.cfg_values = self.config[task_stanza]
 
         # hack to pass parameter into _execute() calls that are not part
         # of command line options

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -580,7 +580,9 @@ class DoitCmdBase(Command):
 
         # Add task options from config, if present
         for task in self.task_list:
-            task.cfg_defaults = self.config.get(task.name, {})
+            task_stanza = 'task:' + task.name
+            if task_stanza in self.config:
+                task.cfg_values = self.config[task_stanza]
 
         # hack to pass parameter into _execute() calls that are not part
         # of command line options

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -578,6 +578,10 @@ class DoitCmdBase(Command):
         if not legacy_loader:
             self.task_list = self.loader.load_tasks(cmd=self, pos_args=args)
 
+        # Add task options from config, if present
+        for task in self.task_list:
+            task.cfg_defaults = self.config.get(task.name, {})
+
         # hack to pass parameter into _execute() calls that are not part
         # of command line options
         params['pos_args'] = args

--- a/doit/cmdparse.py
+++ b/doit/cmdparse.py
@@ -333,7 +333,7 @@ class CmdParse(object):
         return params, args
 
 
-    def parse(self, in_args, cfg_defaults={}):
+    def parse(self, in_args):
         """parse arguments into options(params) and positional arguments
 
         Also get values from shell ENV.
@@ -342,7 +342,6 @@ class CmdParse(object):
         an item for every option.
 
         @param in_args (list - string): typically sys.argv[1:]
-        @param cfg_defaults (dict): dict of values parsed from doit.cfg
         @return params, args
              params(dict): params contain the actual values from the options.
                            where the key is the name of the option.
@@ -352,9 +351,6 @@ class CmdParse(object):
         # add default values
         for opt in self._options.values():
             params.set_default(opt.name, opt.default)
-
-        # apply from doit.cfg
-        params.update(cfg_defaults)
 
         # get values from shell ENV
         for opt in self._options.values():

--- a/doit/cmdparse.py
+++ b/doit/cmdparse.py
@@ -333,7 +333,7 @@ class CmdParse(object):
         return params, args
 
 
-    def parse(self, in_args):
+    def parse(self, in_args, cfg_defaults={}):
         """parse arguments into options(params) and positional arguments
 
         Also get values from shell ENV.
@@ -342,6 +342,7 @@ class CmdParse(object):
         an item for every option.
 
         @param in_args (list - string): typically sys.argv[1:]
+        @param cfg_defaults (dict): dict of values parsed from doit.cfg
         @return params, args
              params(dict): params contain the actual values from the options.
                            where the key is the name of the option.
@@ -351,6 +352,9 @@ class CmdParse(object):
         # add default values
         for opt in self._options.values():
             params.set_default(opt.name, opt.default)
+
+        # apply from doit.cfg
+        params.update(cfg_defaults)
 
         # get values from shell ENV
         for opt in self._options.values():

--- a/doit/control.py
+++ b/doit/control.py
@@ -158,7 +158,9 @@ class TaskControl(object):
                 the_task = self.tasks[f_name]
                 # remaining items are other tasks not positional options
                 taskcmd = TaskParse([CmdOption(opt) for opt in the_task.params])
-                the_task.options, seq = taskcmd.parse(seq, the_task.cfg_defaults)
+                if the_task.cfg_values is not None:
+                    taskcmd.overwrite_defaults(the_task.cfg_values)
+                the_task.options, seq = taskcmd.parse(seq)
                 # if task takes positional parameters set all as pos_arg_val
                 if the_task.pos_arg is not None:
                     the_task.pos_arg_val = seq

--- a/doit/control.py
+++ b/doit/control.py
@@ -156,11 +156,10 @@ class TaskControl(object):
             if f_name in self.tasks:
                 # parse task_selection
                 the_task = self.tasks[f_name]
-                # remaining items are other tasks not positional options
-                taskcmd = TaskParse([CmdOption(opt) for opt in the_task.params])
-                if the_task.cfg_values is not None:
-                    taskcmd.overwrite_defaults(the_task.cfg_values)
-                the_task.options, seq = taskcmd.parse(seq)
+
+                # Initialize options for the task
+                seq = the_task.init_options(seq)
+
                 # if task takes positional parameters set all as pos_arg_val
                 if the_task.pos_arg is not None:
                     the_task.pos_arg_val = seq

--- a/doit/control.py
+++ b/doit/control.py
@@ -158,7 +158,7 @@ class TaskControl(object):
                 the_task = self.tasks[f_name]
                 # remaining items are other tasks not positional options
                 taskcmd = TaskParse([CmdOption(opt) for opt in the_task.params])
-                the_task.options, seq = taskcmd.parse(seq)
+                the_task.options, seq = taskcmd.parse(seq, the_task.cfg_defaults)
                 # if task takes positional parameters set all as pos_arg_val
                 if the_task.pos_arg is not None:
                     the_task.pos_arg_val = seq

--- a/doit/control.py
+++ b/doit/control.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import re
 
 from .exceptions import InvalidTask, InvalidCommand, InvalidDodoFile
-from .cmdparse import TaskParse, CmdOption
 from .task import Task, DelayedLoaded
 from .loader import generate_tasks
 

--- a/doit/task.py
+++ b/doit/task.py
@@ -362,9 +362,10 @@ class Task(object):
     def init_options(self, args=None):
         """Put default values on options.
 
-        This can be called with optional command line task arguments.
+        This function will only initialize task options once. If provided the args
+        parameter will be parsed for command line arguments intended for this task.
 
-        Return value: unparsed command line task arguments.
+        Return value: unparsed command line task arguments or None.
         """
         if self.options is None:
             self.options = {}
@@ -380,7 +381,6 @@ class Task(object):
                 parsed_options, args = taskcmd.parse(args)
                 self.options.update(parsed_options)
                 return args
-
 
     def _init_getargs(self):
         """task getargs attribute define implicit task dependencies"""

--- a/doit/task.py
+++ b/doit/task.py
@@ -367,16 +367,18 @@ class Task(object):
         Return value: unparsed command line task arguments.
         """
         if self.options is None:
+            self.options = {}
             taskcmd = TaskParse([CmdOption(opt) for opt in self.params])
             if self.cfg_values is not None:
                 taskcmd.overwrite_defaults(self.cfg_values)
 
             if args is None:
                 # ignore positional parameters
-                self.options = taskcmd.parse('')[0]
+                self.options.update(taskcmd.parse('')[0])
                 return None
             else:
-                self.options, args = taskcmd.parse(args)
+                parsed_options, args = taskcmd.parse(args)
+                self.options.update(parsed_options)
                 return args
 
 

--- a/doit/task.py
+++ b/doit/task.py
@@ -131,7 +131,7 @@ class Task(object):
     @ivar pos_arg_val: (list - str) list of positional parameters values
     @ivar custom_title: function reference that takes a task object as
                         parameter and returns a string.
-    @ivar cfg_defaults: Default task parameters from doit.cfg
+    @ivar cfg_values: Default task parameters from doit.cfg
     """
 
     DEFAULT_VERBOSITY = 1
@@ -155,7 +155,6 @@ class Task(object):
                   'getargs': ((dict,), ()),
                   'title': ((Callable,), (None,)),
                   'watch': ((list, tuple), ()),
-                  'cfg_defaults': ((dict,), ()),
     }
 
 
@@ -165,7 +164,7 @@ class Task(object):
                  subtask_of=None, has_subtask=False,
                  doc=None, params=(), pos_arg=None,
                  verbosity=None, title=None, getargs=None,
-                 watch=(), loader=None, cfg_defaults=dict()):
+                 watch=(), loader=None, cfg_values=None):
         """sanity checks and initialization
 
         @param params: (list of dict for parameters) see cmdparse.CmdOption
@@ -191,7 +190,6 @@ class Task(object):
         self.check_attr(name, 'getargs', getargs, self.valid_attr['getargs'])
         self.check_attr(name, 'title', title, self.valid_attr['title'])
         self.check_attr(name, 'watch', watch, self.valid_attr['watch'])
-        self.check_attr(name, 'cfg_defaults', cfg_defaults, self.valid_attr['cfg_defaults'])
 
         if '=' in name:
             msg = "Task '{}': name must not use the char '=' (equal sign)."
@@ -233,7 +231,7 @@ class Task(object):
         self.values = {}
         self.verbosity = verbosity
         self.custom_title = title
-        self.cfg_defaults = cfg_defaults
+        self.cfg_values = cfg_values
 
         # clean
         if clean is True:
@@ -370,8 +368,10 @@ class Task(object):
         """
         if self.options is None:
             taskcmd = TaskParse([CmdOption(opt) for opt in self.params])
+            if self.cfg_values is not None:
+                taskcmd.overwrite_defaults(self.cfg_values)
             # ignore positional parameters
-            self.options = taskcmd.parse('', cfg_defaults=self.cfg_defaults)[0]
+            self.options = taskcmd.parse('')[0]
 
 
     def _init_getargs(self):

--- a/doit/task.py
+++ b/doit/task.py
@@ -131,6 +131,7 @@ class Task(object):
     @ivar pos_arg_val: (list - str) list of positional parameters values
     @ivar custom_title: function reference that takes a task object as
                         parameter and returns a string.
+    @ivar cfg_defaults: Default task parameters from doit.cfg
     """
 
     DEFAULT_VERBOSITY = 1
@@ -154,6 +155,7 @@ class Task(object):
                   'getargs': ((dict,), ()),
                   'title': ((Callable,), (None,)),
                   'watch': ((list, tuple), ()),
+                  'cfg_defaults': ((dict,), ()),
     }
 
 
@@ -163,7 +165,7 @@ class Task(object):
                  subtask_of=None, has_subtask=False,
                  doc=None, params=(), pos_arg=None,
                  verbosity=None, title=None, getargs=None,
-                 watch=(), loader=None):
+                 watch=(), loader=None, cfg_defaults=dict()):
         """sanity checks and initialization
 
         @param params: (list of dict for parameters) see cmdparse.CmdOption
@@ -189,6 +191,7 @@ class Task(object):
         self.check_attr(name, 'getargs', getargs, self.valid_attr['getargs'])
         self.check_attr(name, 'title', title, self.valid_attr['title'])
         self.check_attr(name, 'watch', watch, self.valid_attr['watch'])
+        self.check_attr(name, 'cfg_defaults', cfg_defaults, self.valid_attr['cfg_defaults'])
 
         if '=' in name:
             msg = "Task '{}': name must not use the char '=' (equal sign)."
@@ -230,6 +233,7 @@ class Task(object):
         self.values = {}
         self.verbosity = verbosity
         self.custom_title = title
+        self.cfg_defaults = cfg_defaults
 
         # clean
         if clean is True:
@@ -367,7 +371,7 @@ class Task(object):
         if self.options is None:
             taskcmd = TaskParse([CmdOption(opt) for opt in self.params])
             # ignore positional parameters
-            self.options = taskcmd.parse('')[0]
+            self.options = taskcmd.parse('', cfg_defaults=self.cfg_defaults)[0]
 
 
     def _init_getargs(self):

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -146,6 +146,8 @@ class TestModuleTaskLoader(object):
         assert {'verbose': 2} == config
 
     def test_task_config(self):
+        'Ensure that doit.cfg specified task parameters are applied.'
+
         cmd = Command()
         members = {'task_foo': lambda: {'actions':[],
                                         'params': [{

--- a/tests/test_cmd_base.py
+++ b/tests/test_cmd_base.py
@@ -145,6 +145,23 @@ class TestModuleTaskLoader(object):
         assert ['xxx1'] == [t.name for t in task_list]
         assert {'verbose': 2} == config
 
+    def test_task_config(self):
+        cmd = Command()
+        members = {'task_foo': lambda: {'actions':[],
+                                        'params': [{
+                                            'name': 'x',
+                                            'default': None,
+                                            'long': 'x'
+                                        }]},
+                   'DOIT_CONFIG': {'task:foo': {'x': 1}},
+                   }
+        loader = ModuleTaskLoader(members)
+        loader.setup({})
+        loader.config = loader.load_doit_config()
+        task_list = loader.load_tasks(cmd, [])
+        task = task_list.pop()
+        task.init_options()
+        assert 1 == task.options['x']
 
 class TestDodoTaskLoader(object):
     def test_load_tasks(self, restore_cwd):

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -59,44 +59,45 @@ class TestTaskControlInit(object):
         TaskControl([t1, t2, t3])
         assert ['taskZ', 'taskX'] == t2.task_dep
 
-
-TASKS_SAMPLE = [Task("t1", [""], doc="t1 doc string"),
-                Task("t2", [""], doc="t2 doc string"),
-                Task("g1", None, doc="g1 doc string"),
-                Task("g1.a", [""], doc="g1.a doc string", subtask_of='g1'),
-                Task("g1.b", [""], doc="g1.b doc string", subtask_of='g1'),
-                Task("t3", [""], doc="t3 doc string",
-                     params=[{'name':'opt1','long':'message','default':''}])]
-
+@pytest.fixture
+def tasks_sample():
+    return [Task("t1", [""], doc="t1 doc string"),
+            Task("t2", [""], doc="t2 doc string"),
+            Task("g1", None, doc="g1 doc string"),
+            Task("g1.a", [""], doc="g1.a doc string", subtask_of='g1'),
+            Task("g1.b", [""], doc="g1.b doc string", subtask_of='g1'),
+            Task("t3", [""], doc="t3 doc string",
+                params=[{'name':'opt1','long':'message','default':''}])
+            ]
 
 class TestTaskControlCmdOptions(object):
-    def testFilter(self):
+    def testFilter(self, tasks_sample):
         filter_ = ['t2', 't3']
-        tc = TaskControl(TASKS_SAMPLE)
+        tc = TaskControl(tasks_sample)
         assert filter_ == tc._filter_tasks(filter_)
 
-    def testProcessSelection(self):
+    def testProcessSelection(self, tasks_sample):
         filter_ = ['t2', 't3']
-        tc = TaskControl(TASKS_SAMPLE)
+        tc = TaskControl(tasks_sample)
         tc.process(filter_)
         assert filter_ == tc.selected_tasks
 
-    def testProcessAll(self):
-        tc = TaskControl(TASKS_SAMPLE)
+    def testProcessAll(self, tasks_sample):
+        tc = TaskControl(tasks_sample)
         tc.process(None)
         assert ['t1', 't2', 'g1', 'g1.a', 'g1.b', 't3'] == tc.selected_tasks
 
-    def testFilterPattern(self):
-        tc = TaskControl(TASKS_SAMPLE)
+    def testFilterPattern(self, tasks_sample):
+        tc = TaskControl(tasks_sample)
         assert ['t1', 'g1', 'g1.a', 'g1.b'] == tc._filter_tasks(['*1*'])
 
-    def testFilterSubtask(self):
+    def testFilterSubtask(self, tasks_sample):
         filter_ = ["t1", "g1.b"]
-        tc =  TaskControl(TASKS_SAMPLE)
+        tc =  TaskControl(tasks_sample)
         assert filter_ == tc._filter_tasks(filter_)
 
-    def testFilterTarget(self):
-        tasks = list(TASKS_SAMPLE)
+    def testFilterTarget(self, tasks_sample):
+        tasks = list(tasks_sample)
         tasks.append(Task("tX", [""],[],["targetX"]))
         tc =  TaskControl(tasks)
         assert ['tX'] == tc._filter_tasks(["targetX"])
@@ -184,8 +185,8 @@ class TestTaskControlCmdOptions(object):
 
 
     # filter a non-existent task raises an error
-    def testFilterWrongName(self):
-        tc =  TaskControl(TASKS_SAMPLE)
+    def testFilterWrongName(self, tasks_sample):
+        tc =  TaskControl(tasks_sample)
         pytest.raises(InvalidCommand, tc._filter_tasks, ['no'])
 
     def testFilterWrongSubtaskName(self):
@@ -194,19 +195,19 @@ class TestTaskControlCmdOptions(object):
         tc =  TaskControl([t1, t2])
         pytest.raises(InvalidCommand, tc._filter_tasks, ['taskX:no'])
 
-    def testFilterEmptyList(self):
+    def testFilterEmptyList(self, tasks_sample):
         filter_ = []
-        tc = TaskControl(TASKS_SAMPLE)
+        tc = TaskControl(tasks_sample)
         assert filter_ == tc._filter_tasks(filter_)
 
-    def testOptions(self):
+    def testOptions(self, tasks_sample):
         options = ["t3", "--message", "hello option!", "t1"]
-        tc = TaskControl(TASKS_SAMPLE)
+        tc = TaskControl(tasks_sample)
         assert ['t3', 't1'] == tc._filter_tasks(options)
         assert "hello option!" == tc.tasks['t3'].options['opt1']
 
-    def testPosParam(self):
-        tasks = list(TASKS_SAMPLE)
+    def testPosParam(self, tasks_sample):
+        tasks = list(tasks_sample)
         tasks.append(Task("tP", [""],[],[], pos_arg='myp'))
         tc = TaskControl(tasks)
         args = ["tP", "hello option!", "t1"]

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -119,6 +119,7 @@ class TestTaskInit(object):
         assert None == t.pos_arg_val # always uninitialized
 
     def test_options_from_cfg(self):
+        'Ensure that doit.cfg can specify task options.'
         p1 = {'name': 'x', 'long': 'x', 'default': None}
         t = task.Task("MyName", None, params=[p1])
         t.cfg_values = {'x': 1}
@@ -128,13 +129,17 @@ class TestTaskInit(object):
         assert 1 == t.options['x']
 
     def test_options_from_cfg_override(self):
+        'Ensure that doit.cfg specified task options can be replaced by command line specified options.'
+
         p1 = {'name': 'x', 'long': 'x', 'default': None, 'type': int}
-        t = task.Task("MyName", None, params=[p1])
+        p2 = {'name': 'y', 'long': 'y', 'default': 2, 'type': int}
+        t = task.Task("MyName", None, params=[p1, p2])
         t.cfg_values = {'x': 1}
         assert t.options is None
         t.init_options(['--x=2'])
         assert t.options is not None
         assert 2 == t.options['x']
+        assert 2 == t.options['y']
 
     def test_setup(self):
         t = task.Task("task5", ['action'], setup=["task2"])

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -118,6 +118,24 @@ class TestTaskInit(object):
         assert 'pos' == t.pos_arg
         assert None == t.pos_arg_val # always uninitialized
 
+    def test_options_from_cfg(self):
+        p1 = {'name': 'x', 'long': 'x', 'default': None}
+        t = task.Task("MyName", None, params=[p1])
+        t.cfg_values = {'x': 1}
+        assert t.options is None
+        t.init_options()
+        assert t.options is not None
+        assert 1 == t.options['x']
+
+    def test_options_from_cfg_override(self):
+        p1 = {'name': 'x', 'long': 'x', 'default': None, 'type': int}
+        t = task.Task("MyName", None, params=[p1])
+        t.cfg_values = {'x': 1}
+        assert t.options is None
+        t.init_options(['--x=2'])
+        assert t.options is not None
+        assert 2 == t.options['x']
+
     def test_setup(self):
         t = task.Task("task5", ['action'], setup=["task2"])
         assert ["task2"] == t.setup_tasks


### PR DESCRIPTION
doit.cfg options take precedence over task definition default values
but with be replaced by task parameters passed on the command line.

TODO:

- [x] Implement `[task:arg_from_cfg]`
- [x] Rename `cfg_defaults` to `cfg_values`
- [x] Remove task config checks for `cfg_values` parameter
- [x] Use `.overwrite_defaults()` to apply `cfg_values`
- [x] Refactor `control.py` per comment
- [x] Tests
    - Ensure that doit.cfg specified task parameters are applied.
- [x] Documentation

Implements #283 

Demo:

```
$ cat dodo.py
def task_arg_from_cfg():
    def runit(x=1, y=1):
        print(f'python x={x}, y={y}')
        # if x==1: raise ValueError()

    return {
        'actions': [runit, 'echo shell x=%(x)s y=%(y)s'],
        'params': [{'default': 1, 'name': 'x', 'long': 'x'}, {'default': 2, 'name': 'y', 'long': 'y'}],
        'verbosity': 2,
}
```
```
$ cat doit.cfg
[task:arg_from_cfg]
    x = 1000
```
```
$ doit
.  arg_from_cfg
python x=1000, y=2
shell x=1000 y=2

```
```
$ doit run arg_from_cfg
.  arg_from_cfg
python x=1000, y=2
shell x=1000 y=2

```
```
$ doit run arg_from_cfg --x=123
.  arg_from_cfg
python x=123, y=2
shell x=123 y=2

```
