### PR TITLE
`@task_param()` decorator to pass command line parameters to task generators and `@create_after` for class defined tasks

### DIFF
--- a/doc/task_args.rst
+++ b/doc/task_args.rst
@@ -1,13 +1,13 @@
 
-Passing Task Arguments from the command line
+Passing arguments from the command line
 ============================================
 
 .. _parameters:
 
-arguments
+Task action arguments
 -----------
 
-It is possible to pass option parameters to the task through the command line.
+It is possible to pass option parameters to the task action through the command line.
 
 Just add a ``params`` field to the task dictionary. ``params`` must be a list of
 dictionaries where every entry is an option parameter. Each parameter must
@@ -69,8 +69,6 @@ For cmd-actions use python string substitution notation:
     $ doit cmd_params -f "-c --other value"
     .  cmd_params
     mycmd -c --other value xxx
-
-
 
 .. _parameters-attributes:
 
@@ -206,3 +204,35 @@ It is possible to pass variable values to be used in dodo.py from the command li
     $ doit abc=xyz x=3
     .  echo
     hi {abc: xyz}
+
+Task generator arguments
+-----------
+
+Command line arguments may also be defined for a task generating function or method
+using the same parameter syntax as is used with task action parameters.
+
+.. code-block:: python
+
+    from doit import task_param
+
+    @task_param([{"name": "howmany", "default": 3, "type": int, "long": "howmany"}])
+    def task_subtasks(howmany):
+        for i in range(howmany):
+            yield {"name": i, "actions": [f"echo I can count to {howmany}: {i}"]}
+
+Any argument defined for the task generating function will also be available as an
+argument for any task actions.
+
+.. code-block:: python
+
+    def do_work(foo):
+        print(f'Argument foo={foo}')
+
+    @task_param([{"name": "foo", "default": "bar", "long": "foo"}])
+    def task_use_in_action(foo):
+        print(f'When the task action runs it will print {foo}')
+
+        return {
+            'actions': [do_work],
+            'verbosity': 2
+        }

--- a/doit/__init__.py
+++ b/doit/__init__.py
@@ -29,7 +29,7 @@ __version__ = VERSION
 
 
 from doit import loader
-from doit.loader import create_after
+from doit.loader import create_after, task_param
 from doit.doit_cmd import get_var
 from doit.api import run
 from doit.tools import load_ipython_extension

--- a/doit/__init__.py
+++ b/doit/__init__.py
@@ -36,7 +36,7 @@ from doit.tools import load_ipython_extension
 from doit.globals import Globals
 
 
-__all__ = ['get_var', 'run', 'create_after', 'Globals']
+__all__ = ['get_var', 'run', 'create_after', 'task_param', 'Globals']
 
 def get_initial_workdir():
     """working-directory from where the doit command was invoked on shell"""

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -384,8 +384,8 @@ class NamespaceTaskLoader(TaskLoader2):
         return loader.load_doit_config(self.namespace)
 
     def load_tasks(self, cmd, pos_args):
-        tasks = loader.load_tasks(self.namespace, self.cmd_names,
-                                 cmd.execute_tasks)
+        return loader.load_tasks(self.namespace, self.cmd_names,
+                                 cmd.execute_tasks, pos_args)
 
         # Add task options from config, if present
         if self.config is not None:

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -384,7 +384,7 @@ class NamespaceTaskLoader(TaskLoader2):
         return loader.load_doit_config(self.namespace)
 
     def load_tasks(self, cmd, pos_args):
-        return loader.load_tasks(self.namespace, self.cmd_names,
+        tasks = loader.load_tasks(self.namespace, self.cmd_names,
                                  cmd.execute_tasks, pos_args)
 
         # Add task options from config, if present

--- a/doit/control.py
+++ b/doit/control.py
@@ -466,7 +466,7 @@ class TaskDispatcher(object):
             to_load = this_task.loader.basename or this_task.name
             this_loader = self.tasks[to_load].loader
             if this_loader and not this_loader.created:
-                new_tasks = generate_tasks(to_load, ref(), ref.__doc__)
+                new_tasks = generate_tasks(to_load, ref(**ref.doit_task_generator_params), ref.__doc__)
                 TaskControl.set_implicit_deps(self.targets, new_tasks)
                 for nt in new_tasks:
                     if not nt.loader:

--- a/doit/control.py
+++ b/doit/control.py
@@ -6,7 +6,7 @@ import re
 
 from .exceptions import InvalidTask, InvalidCommand, InvalidDodoFile
 from .task import Task, DelayedLoaded
-from .loader import generate_tasks
+from .loader import generate_tasks, TASK_GEN_PARAM, TASK_GEN_PARAM_DEFAULT
 
 
 class RegexGroup(object):
@@ -466,7 +466,8 @@ class TaskDispatcher(object):
             to_load = this_task.loader.basename or this_task.name
             this_loader = self.tasks[to_load].loader
             if this_loader and not this_loader.created:
-                new_tasks = generate_tasks(to_load, ref(**ref.doit_task_generator_params), ref.__doc__)
+                task_gen = getattr(ref, TASK_GEN_PARAM, TASK_GEN_PARAM_DEFAULT)
+                new_tasks = generate_tasks(to_load, ref(**task_gen['parsed']), ref.__doc__)
                 TaskControl.set_implicit_deps(self.targets, new_tasks)
                 for nt in new_tasks:
                     if not nt.loader:

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -113,12 +113,10 @@ def create_after(executed=None, target_regex=None, creates=None):
 def task_param(param_def=None):
     """Annotate a task-creator function with definition of required parameters"""
 
-    print(f'Preparing decorator with {param_def}')
     if param_def is None or type(param_def) != list:
         raise ValueError('task_param must be called with a valid parameter definition.')
     
     def decorated(func):
-        print(f'decorating {func}')
         func.doit_task_param_def = param_def
         return func
     

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -186,13 +186,12 @@ def load_tasks(namespace, command_names=(), allow_delayed=False, args=''):
             parser = TaskParse([CmdOption(opt) for opt in task_gen['params']])
             # Annotate the task generator with parsed parameter values so that when
             # the task is eventually called the parsed parameters are available.
+            task_gen['parsed'], _ = parser.parse('')
+
+            # if relevant command line defaults are available parse those
             if len(args) > 0:
                 if name == args[0]:
-                    # parse command line
                     task_gen['parsed'], _ = parser.parse(args[1:])
-            else:
-                # set defaults
-                task_gen['parsed'], _ = parser.parse('')
 
         if not delayed:  # not a delayed task, just run creator
             _process_gen(ref)

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -20,6 +20,7 @@ initial_workdir = None
 TASK_STRING = "task_"
 
 TASK_GEN_PARAM = 'doit_task_generator_parameters'
+TASK_GEN_PARAM_DEFAULT = {'params': [], 'parsed': {}}
 
 def flat_generator(gen, gen_doc=''):
     """return only values from generators
@@ -121,11 +122,12 @@ def task_param(param_def=None):
         # For tasks defined as a method this must
         # be a dict. Once bound to an instance the function
         # attributes can not be modified.
-        setattr(func, TASK_GEN_PARAM, {
-            'params': param_def
-        })
+        # https://www.python.org/dev/peps/pep-0232/#id15
+        pd = TASK_GEN_PARAM_DEFAULT.copy()
+        pd['params'] = param_def
+        setattr(func, TASK_GEN_PARAM, pd)
         return func
-    
+
     return decorated
 
 def load_tasks(namespace, command_names=(), allow_delayed=False, args=''):
@@ -158,9 +160,9 @@ def load_tasks(namespace, command_names=(), allow_delayed=False, args=''):
             # TODO: Check for duplicates?
             task.params = tuple(list(task.params) + param_def)
         return tasks
-            
+
     def _process_gen(ref):
-        task_gen = getattr(ref, TASK_GEN_PARAM, {'params': [], 'parsed': {}})
+        task_gen = getattr(ref, TASK_GEN_PARAM, TASK_GEN_PARAM_DEFAULT)
         task_list.extend(_append_params(generate_tasks(name, ref(**task_gen['parsed']), ref.__doc__), task_gen['params']))
 
     def _add_delayed(tname, ref):

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -158,7 +158,9 @@ def load_tasks(namespace, command_names=(), allow_delayed=False, args=''):
         'Apply parameters defined for the task generator to the tasks defined by the generator.'
         for task in tasks:
             # TODO: Check for duplicates?
-            task.params = tuple(list(task.params) + param_def)
+            if task.subtask_of is None:
+                # only parent tasks
+                task.params = tuple(list(task.params) + param_def)
         return tasks
 
     def _process_gen(ref):

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -136,7 +136,15 @@ def load_tasks(namespace, command_names=(), allow_delayed=False):
     task_list = []
     def _process_gen():
         task_list.extend(generate_tasks(name, ref(), ref.__doc__))
-    def _add_delayed(tname):
+    def _add_delayed(tname, ref):
+        # If ref is a bound method this updates the DelayedLoader specification
+        # so that when delayed.creator is executed later (control.py:469) the
+        # self parameter is provided. control.py:469 may execute this function
+        # with any additional parameters.
+        #
+        # If ref is NOT a method this this line simply re-assigns the
+        # same function.
+        delayed.creator = ref
         task_list.append(Task(tname, None, loader=delayed,
                               doc=delayed.creator.__doc__))
 
@@ -147,9 +155,9 @@ def load_tasks(namespace, command_names=(), allow_delayed=False):
             _process_gen()
         elif delayed.creates:  # delayed with explicit task basename
             for tname in delayed.creates:
-                _add_delayed(tname)
+                _add_delayed(tname, ref)
         elif allow_delayed:  # delayed no explicit name, cmd run
-            _add_delayed(name)
+            _add_delayed(name, ref)
         else:  # delayed no explicit name, cmd list (run creator)
             _process_gen()
 

--- a/doit/loader.py
+++ b/doit/loader.py
@@ -113,10 +113,12 @@ def create_after(executed=None, target_regex=None, creates=None):
 def task_param(param_def=None):
     """Annotate a task-creator function with definition of required parameters"""
 
+    print(f'Preparing decorator with {param_def}')
     if param_def is None or type(param_def) != list:
         raise ValueError('task_param must be called with a valid parameter definition.')
     
     def decorated(func):
+        print(f'decorating {func}')
         func.doit_task_param_def = param_def
         return func
     
@@ -206,6 +208,10 @@ def _get_task_creators(namespace, command_names):
     prefix_len = len(TASK_STRING)
     # get all functions that are task-creators
     for name, ref in namespace.items():
+
+        # Do not solicit tasks from the @task_param decorator.
+        if ref == task_param:
+            continue
 
         # function is a task creator because of its name
         if name.startswith(TASK_STRING) and (

--- a/doit/task.py
+++ b/doit/task.py
@@ -373,14 +373,14 @@ class Task(object):
             if self.cfg_values is not None:
                 taskcmd.overwrite_defaults(self.cfg_values)
 
-            if args is None:
+            if args is None or len(args) == 0:
                 # ignore positional parameters
                 self.options.update(taskcmd.parse('')[0])
-                return None
-            else:
+            elif len(args) > 0:
                 parsed_options, args = taskcmd.parse(args)
                 self.options.update(parsed_options)
-                return args
+
+            return args
 
     def _init_getargs(self):
         """task getargs attribute define implicit task dependencies"""

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -131,6 +131,38 @@ class TestLoadTasks(object):
         assert tasks['bar'].loader is tasks['foo'].loader
         assert tasks['foo'].doc == 'not loaded task doc'
 
+    def testClassCreateAfterDecorator(self):
+        'Check that class-defined tasks are loaded as bound methods'
+        class Tasks:
+            @create_after('yyy2')
+            def task_zzz3(): # pragma: no cover
+                pass
+
+        # create_after annotates the function
+        task_list = load_tasks({'task_zzz3': Tasks().task_zzz3}, allow_delayed=True)
+        tasks = {t.name:t for t in task_list}
+        task_zzz3 = tasks['zzz3']
+        assert isinstance(task_zzz3.loader, DelayedLoader)
+        assert getattr(task_zzz3.loader.creator, '__self__', None) is not None, 'Class-defined delayed task creating method is not bound'
+
+    def testClassInitialLoadDelayedTask_creates(self, dodo):
+        'Check that class-defined tasks support the creates argument of @create_after'       
+        class Tasks:
+            @create_after('yyy2', creates=['foo', 'bar'])
+            def task_zzz3(): # pragma: no cover
+                '''not loaded task doc'''
+                raise Exception('Cant be executed on load phase')
+
+        # placeholder task is created with `loader` attribute
+        task_list = load_tasks({'task_zzz3': Tasks().task_zzz3}, allow_delayed=True)
+        tasks = {t.name:t for t in task_list}
+        assert 'zzz3' not in tasks
+        f_task = tasks['foo']
+        assert f_task.loader.task_dep == 'yyy2'
+        assert getattr(f_task.loader.creator, '__self__', None) is not None, 'Class-defined delayed task creating method is not bound'
+        assert tasks['bar'].loader is tasks['foo'].loader
+        assert tasks['foo'].doc == 'not loaded task doc'
+
     def testNameInBlacklist(self):
         dodo_module = {'task_cmd_name': lambda:None}
         pytest.raises(InvalidDodoFile, load_tasks, dodo_module, ['cmd_name'])

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -250,19 +250,33 @@ class TestTaskGeneratorParams(object):
     class Tasks(object):
         @task_param([{"name": "foo", "default": "bar", "long": "foo"}])
         def task_foo(self, foo):
-            return {
-                'actions': [],
-                'doc': foo
-            }
+            for i in range(2):
+                yield {
+                    'name': 'subtask' + str(i),
+                    'actions': [],
+                    'doc': foo
+                }
     
     def test_class_default(self):
         'Ensure that a task parameter can be passed to the task generator defined as a class method.'
         foo = self.Tasks().task_foo
         task_list = load_tasks({'task_foo': foo})
-        task = task_list.pop()
-        assert task.doc == 'bar'
-        task.init_options()
-        assert task.options['foo'] == 'bar'
+        
+        assert len(task_list) == 3
+
+        for task in task_list:
+            task.init_options()
+
+            if task.has_subtask:
+                # only parent task gets @task_param value
+                assert len(task.params) == 1
+                assert task.options['foo'] == 'bar'
+                assert task.doc == ''
+            else:
+                # option used to define subtask doc value
+                assert task.doc == 'bar'
+                # subtasks do not get @task_param
+                assert len(task.params) == 0
     
 class TestDodoConfig(object):
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -256,6 +256,13 @@ class TestTaskGeneratorParams(object):
                     'actions': [],
                     'doc': foo
                 }
+        
+        @task_param([{"name": "foo", "default": "decorator", "long": "foo"}])
+        def task_dup(self, foo):
+            return {
+                'actions': [],
+                'params': [{"name": "foo", "default": "dict", "long": "foo"}],
+            }
     
     def test_class_default(self):
         'Ensure that a task parameter can be passed to the task generator defined as a class method.'
@@ -277,7 +284,14 @@ class TestTaskGeneratorParams(object):
                 assert task.doc == 'bar'
                 # subtasks do not get @task_param
                 assert len(task.params) == 0
-    
+
+    def test_dup_param(self):
+        'Ensure that @task_param duplicated task definitions are prohibited'
+        
+        with pytest.raises(InvalidTask):
+            load_tasks({'task_dup': self.Tasks().task_dup})
+        
+
 class TestDodoConfig(object):
 
     def testConfigType_Error(self):


### PR DESCRIPTION
As described in #311 this decorator can be used to pass command line arguments to the task generator. The same parameter definitions are also passed to the generated tasks.

This branch also includes pull request #307 which implements `@create_after()` semantics for tasks defined in a class. As discussed on #307 @schettino72 asked to see code for #311 as well. If this PR is merged then #307 will be closed.

Quick implementation to see if this is what was intended by the issue and to open discussion.

Work to be done:

- [x] actually do the parsing!
- [x] `auto` compatibility
- [x] docs since this is a new user-facing feature
- [x] tests
    - Ensure that a task parameter can be passed to the task generator.
    - Ensure that a task generator parameter can be set from the command line.
    - Ensure that a task parameter can be passed to the task generator defined as a class method.

Demo:

```
$ cat dodo.py
from doit import create_after, task_param


def task_early():
    return {"actions": ["echo early"], "verbosity": 2}


@create_after(executed="early")
@task_param([{"name": "foo", "default": "bar", "long": "foo"}])
def task_use_param_create_after(foo):
    print(f'Task parameter foo={foo} available at task definition time.')

    def runit():
        print(f"param foo={foo}")

    return {"actions": [runit], "verbosity": 2}


@task_param([{"name": "foo", "default": "bar", "long": "foo"}])
def task_use_param(foo):
    print(f'Task parameter foo={foo} available at task definition time.')

    def runit():
        print(f"param foo={foo}")

    return {"actions": [runit], "verbosity": 2}


@task_param([{"name": "howmany", "default": 3, "type": int, "long": "howmany"}])
def task_subtasks(howmany):
    for i in range(howmany):
        yield {"name": i, "actions": [f"echo I can count to {howmany}: {i}"]}

def do_work(foo):
    print(f'Argument foo={foo}')

@task_param([{"name": "foo", "default": "bar", "long": "foo"}])
def task_use_in_action(foo):
    print(f'When the task action runs it will print {foo}')

    return {
        'actions': [do_work],
        'verbosity': 2
    }

@task_param([{'name': 'num_tasks', 'default': 1, 'type': int, 'long': 'num_tasks'}])
def task_subtask(num_tasks):
    print(f'Generating {num_tasks} subtasks')

    def work(task_num, num_tasks):
        print(f'Task {task_num+1} of {num_tasks}')

    for i in range(0, num_tasks):
        yield {
            'name': f'task{i}',
            'actions': [(work, (), {'task_num': i})],
            'verbosity': 2
        }

```
```
$ cat doit.cfg
[task:use_param_create_after]
    foo = from_doit_cfg
```
```
$ doit
Task parameter foo=bar available at task definition time.
When the task action runs it will print bar
Generating 1 subtasks
.  early
early
Task parameter foo=bar available at task definition time.
.  use_param_create_after
param foo=bar
.  use_param
param foo=bar
.  subtasks:0
.  subtasks:1
.  subtasks:2
.  use_in_action
Argument foo=bar
.  subtask:task0
Task 1 of 1

```
```
$ doit info use_param
Task parameter foo=bar available at task definition time.
Task parameter foo=bar available at task definition time.
When the task action runs it will print bar
Generating 1 subtasks

use_param

status     : run
 * The task has no dependencies.

params     : 
 - {'name': 'foo', 'default': 'bar', 'long': 'foo'}

verbosity  : 2

```
```
$ doit info use_param_create_after
Task parameter foo=bar available at task definition time.
Task parameter foo=bar available at task definition time.
When the task action runs it will print bar
Generating 1 subtasks

use_param_create_after

status     : run
 * The task has no dependencies.

params     : 
 - {'name': 'foo', 'default': 'bar', 'long': 'foo'}

verbosity  : 2

```
