### PR TITLE
New `BaseAction.to_str` method used in particular in `title_with_actions`.

### DIFF
--- a/doit/tools.py
+++ b/doit/tools.py
@@ -23,7 +23,7 @@ def create_folder(dir_path):
 def title_with_actions(task):
     """return task name task actions"""
     if task.actions:
-        title = "\n\t".join([str(action) for action in task.actions])
+        title = "\n\t".join([action.to_str(expand_options=True) for action in task.actions])
     # A task that contains no actions at all
     # is used as group task
     else:

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -168,6 +168,8 @@ class TestCmdExpandAction(object):
         task = Task('Fake', [cmd])
         task.options = {'opt1':'3', 'opt2':'abc def'}
         my_action = task.actions[0]
+        assert my_action.to_str(expand_options=False).endswith('myecho.py %(opt1)s - %(opt2)s')
+        assert my_action.to_str(expand_options=True).endswith('myecho.py 3 - abc def')
         assert my_action.execute() is None
         got = my_action.out.strip()
         assert "3 - abc def" == got
@@ -179,6 +181,8 @@ class TestCmdExpandAction(object):
         task.options = {}
         task.pos_arg_val = ['hi', 'there']
         my_action = task.actions[0]
+        assert my_action.to_str(expand_options=False).endswith('myecho.py %(pos)s')
+        assert my_action.to_str(expand_options=True).endswith('myecho.py hi there')
         assert my_action.execute() is None
         got = my_action.out.strip()
         assert "hi there" == got
@@ -191,6 +195,8 @@ class TestCmdExpandAction(object):
         task = Task('Fake', [cmd], pos_arg='pos')
         task.options = {}
         my_action = task.actions[0]
+        assert my_action.to_str(expand_options=False).endswith('myecho.py %(pos)s')
+        assert my_action.to_str(expand_options=True).endswith('myecho.py ')
         assert my_action.execute() is None
         got = my_action.out.strip()
         assert "" == got
@@ -548,17 +554,21 @@ class TestPythonAction(object):
         pytest.raises(action.InvalidTask, action.PythonAction, any)
 
     def test_functionParametersArgs(self):
-        my_action = action.PythonAction(self._func_par,args=(2,2,25))
+        my_action = action.PythonAction(self._func_par, args=(2,2,25))
+        assert my_action.to_str(expand_options=False).endswith('>')
+        assert my_action.to_str(expand_options=True).endswith('>(2, 2, 25)')
         my_action.execute()
 
     def test_functionParametersKwargs(self):
         my_action = action.PythonAction(self._func_par,
-                              kwargs={'par1':2,'par2':2,'par3':25})
+                                        kwargs={'par1':2,'par2':2,'par3':25})
         my_action.execute()
 
     def test_functionParameters(self):
         my_action = action.PythonAction(self._func_par,args=(2,2),
                                    kwargs={'par3':25})
+        assert my_action.to_str(expand_options=False).endswith('>')
+        assert my_action.to_str(expand_options=True).endswith('>(2, 2, par3=25)')
         my_action.execute()
 
     def test_functionParametersFail(self):


### PR DESCRIPTION
New `BaseAction.to_str` method so that all actions can provide a string representation with or without expanding the options inside. 

This method is used by helper function `title_with_actions`. 

Added corresponding tests. 

Fixes #325

Note that this PR also improves slightly the string representation of python functions, as a side effect.

Still todo: documentation.