### PR TITLE
Un-break CatchedException and derived exceptions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@
  * Michael Milton - https://github.com/tmiguelt
  * Mike Pagel - https://github.com/moltob
  * Marijn van Vliet - https://github.com/wmvanvliet
+ * Martijn Pieters - https://github.com/mjpieters
  * Niko Wenselowski - https://github.com/okin
  * Jan Felix Langenbach - o <dot> hase3 <at> gmail <dot> com
  * Facundo Ciccioli - facundofc <at> gmail <dot> com

--- a/doit/exceptions.py
+++ b/doit/exceptions.py
@@ -42,7 +42,7 @@ class InvalidTask(Exception):
     pass
 
 
-class CatchedException(object):
+class CatchedException(Exception):
     """This used to save info from caught exceptions
     The traceback from the original exception is saved
     """

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from doit import exceptions
 
 
@@ -63,10 +65,19 @@ class TestCatchedException(object):
         assert 'IndexError' in msg
 
 
+@pytest.mark.parametrize(
+    "exception",
+    (
+        exceptions.TaskFailed,
+        exceptions.TaskError,
+        exceptions.SetupError,
+        exceptions.DependencyError
+    )
+)
 class TestAllCatched(object):
-    def test(self):
-        assert issubclass(exceptions.TaskFailed, exceptions.CatchedException)
-        assert issubclass(exceptions.TaskError, exceptions.CatchedException)
-        assert issubclass(exceptions.SetupError, exceptions.CatchedException)
-        assert issubclass(exceptions.DependencyError,
-                          exceptions.CatchedException)
+    def test(self, exception):
+        assert issubclass(exception, exceptions.CatchedException)
+
+    def test_raise(self, exception):
+        with pytest.raises(exception):
+            raise exception("Foo bar baz")


### PR DESCRIPTION
Exceptions must inherit from `BaseException` (in rare cases) or `Exception` (the regular case).

This fixes #338. Ideally, the test suite should actually try and use the subclassed exceptions, however.