### PR TITLE
[doc] A few fixes in tutorial_1.rst

### DIFF
--- a/doc/tutorial_1.rst
+++ b/doc/tutorial_1.rst
@@ -604,7 +604,7 @@ Sub-tasks (items of task group) by default are not reported by the ``list`` comm
 Note the task's name is composed of the task's group name (aka ``basename``)
 followed by a colon `:` and the ``name`` specified as a parameter when ``yield``.
 
-From the command line, a single task can be executed like this:
+From the command line, a single task can be executed like this::
 
   $ doit imports:requests.models
   .  imports:requests.models

--- a/doc/tutorial_1.rst
+++ b/doc/tutorial_1.rst
@@ -534,7 +534,7 @@ and what it does is to execute the task ``task_name``, get the value of ``source
 Note how ``module_to_dot`` takes 3 parameters:
 
 - ``source``: value is passed directly when the task's actions is defined
-- ``imports``: value is taken from ``imports`` task's result
+- ``sinks``: value is taken from ``imports`` task's result
 - ``targets``: values is taken from Task metadata
 
 

--- a/doc/tutorial_1.rst
+++ b/doc/tutorial_1.rst
@@ -671,7 +671,7 @@ While those cover a wide range of use cases, ``doit`` also provides a way to spe
 In this case the ``print`` task actually does not perform any computation, it is being used to display some info to the user.
 So this task should be **always** executed.
 
-``update`` will be explained in detail in part 2 of this tutorial.
+``uptodate`` will be explained in detail in part 2 of this tutorial.
 For now it suffices to add the value ``False`` to indicate this task will never be considered **up-do-date**.
 
 .. code-block:: python


### PR DESCRIPTION
This now matches the names of parameters in `tuto_1_2.py`