### PR TITLE
Use multiprocess if available

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,3 @@
-
 =======
 Changes
 =======
@@ -8,6 +7,7 @@ Changes
 
  - python 3.8 support
  - BACKWARD INCOMPATIBLE: Drop Python 3.4 support
+ - support `multiprocess` and require it for Windows
 
 
 0.32.0 (*2019-12-10*)
@@ -527,4 +527,3 @@ Changes
 ====================
 
 - initial release
-

--- a/doc/cmd_run.rst
+++ b/doc/cmd_run.rst
@@ -240,6 +240,8 @@ parallel execution
 This allows different tasks to be run in parallel, as long any dependencies are met.
 By default the `multiprocessing <http://docs.python.org/library/multiprocessing.html>`_
 module is used.
+If the `multiprocess <https://pypi.org/project/multiprocess/>`_ module is installed,
+it will be used instead.
 So the same restrictions also apply to the use of multiprocessing in `doit`.
 
 .. code-block:: console

--- a/doit/cmd_auto.py
+++ b/doit/cmd_auto.py
@@ -4,7 +4,10 @@ automatically execute tasks when file dependencies change"""
 import os
 import time
 import sys
-from multiprocessing import Process
+try:
+    from multiprocess import Process
+except ImportError:
+    from multiprocessing import Process
 from subprocess import call
 
 from .exceptions import InvalidCommand

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -1,6 +1,9 @@
 """Task runner"""
 
-from multiprocessing import Process, Queue as MQueue
+try:
+    from multiprocess import Process, Queue as MQueue
+except ImportError:
+    from multiprocessing import Process, Queue as MQueue
 from threading import Thread
 import pickle
 import queue

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(name = 'doit',
       extras_require={
           ':sys.platform == "darwin"': ['macfsevents'],
           ':sys.platform == "linux"': ['pyinotify'],
+          ':sys.platform == "win32"': ['multiprocess'],
       },
       long_description = long_description,
       entry_points = {

--- a/tests/test_cmd_auto.py
+++ b/tests/test_cmd_auto.py
@@ -1,5 +1,8 @@
 import time
-from multiprocessing import Process
+try:
+    from multiprocess import Process
+except ImportError:
+    from multiprocessing import Process
 
 import pytest
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,9 @@
 import os
 import pickle
-from multiprocessing import Queue
+try:
+    from multiprocess import Queue
+except ImportError:
+    from multiprocessing import Queue
 import platform
 from unittest.mock import Mock
 


### PR DESCRIPTION
Windows doesn't have a true `fork` implementation, so multiprocessing and pickling are limited compared to other platforms. There are also some situations in Linux / Mac OS X where we would like to pickle something, but it does not work without some code changes. This PR makes pickling for mulitprocessing work in more situations by using the [`multiprocess`](https://pypi.org/project/multiprocess/) library, if it's available.`multiprocess` is a fork of `multiprocessing` that uses [`dill`](https://pypi.org/project/dill/) instead of `pickle`.

This PR is set up such that we do not require the user to have `multiprocess` installed, but if it is installed we'll use it -- except in Windows, where pickling is so limited that it will make things easier to require it. There are a few other routes we could go:

1. **Don't require it in Windows**: This makes things simpler for Windows users who don't want to use multiprocessing. Installing the `multiprocess` package should work on all platforms, but if there's a platform where there are likely to be issues, it's Windows.

2. **Require it for all platforms**: This will likely be a net benefit to everyone, but it introduces a new dependency. Also, `dill` will always be a little bit slower than `pickle` since it's able to pickle more things. However, if we're not pickling anything too large anyway, performance shouldn't be an issue, and it would be possible to simplify some parts of the codebase by using `dill` instead of `cloudpickle` and removing some of the hacks that we currently use to get Windows to pickle things that it normally can't.

I'm happy to modify this PR to implement either option if you want! I've been using `doit` for a relatively large data science project and it's been a huge help.