### PR TITLE
Remove pip import and version check from setup.py to make doit install with setuptools 50.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,6 @@ import sys
 from setuptools import setup
 
 
-
-########### last version to support python2 is 0.29 ####
-try:
-    import pip
-    pip_version = tuple([int(x) for x in pip.__version__.split('.')[:3]])
-    if pip_version < (9, 0, 1) :
-        pip_message = 'Your pip version is out of date, please install pip >= 9.0.1. '\
-                      'pip {} detected.'.format(pip.__version__)
-        print(pip_message, file=sys.stderr)
-        sys.exit(1)
-except Exception:
-    # what if someone does not have pip installed
-    pass
-
-########################################################
-
-
 long_description = """
 `doit` is a task management & automation tool
 


### PR DESCRIPTION
Changes to how setuptools 50 works means that installing doit crashes with a cryptic KeyError (most likely caused by setuptools and pip’s monkeypatching of distutils). This check is not really necessary (most people have a newer pip these days).

---
Error:

```pytb
$ ./setup.py
/tmp/venv/lib64/python3.8/site-packages/_distutils_hack/__init__.py:30: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
Traceback (most recent call last):
  File "./setup.py", line 44, in <module>
    setup(name = 'doit',
  File "/tmp/venv/lib64/python3.8/site-packages/setuptools/__init__.py", line 152, in setup
    _install_setup_requires(attrs)
  File "/tmp/venv/lib64/python3.8/site-packages/setuptools/__init__.py", line 145, in _install_setup_requires
    dist.parse_config_files(ignore_option_errors=True)
  File "/tmp/venv/lib64/python3.8/site-packages/setuptools/dist.py", line 665, in parse_config_files
    self._parse_config_files(filenames=filenames)
  File "/tmp/venv/lib64/python3.8/site-packages/setuptools/dist.py", line 572, in _parse_config_files
    filenames = self.find_config_files()
  File "/tmp/venv/lib64/python3.8/site-packages/setuptools/_distutils/dist.py", line 353, in find_config_files
    sys_dir = os.path.dirname(sys.modules['distutils'].__file__)
KeyError: 'distutils'
```

---

Please consider making a new release to PyPI, since this makes it hard to install doit (and its dependents, like Nikola). Please also consider adding wheels to the PyPI release to simplify installation (`./setup.py sdist bdist_wheel` to build, then upload both files).