### PR TITLE
Add -a/--all option to doit forget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@
  * Jan Felix Langenbach - o <dot> hase3 <at> gmail <dot> com
  * Facundo Ciccioli - facundofc <at> gmail <dot> com
  * Alexandre Allard - https://github.com/alexandre-allard-scality
+ * Trevor Bekolay - https://github.com/tbekolay

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Changes
 - Fix #373: read DOIT_CONFIG from TOML.
 - Fix #405: Add Task attribute `meta`.
 - Fix #349: Handle passing task args in "single" task execution.
+- Fix #377: Add --disable-default-all and --all options to forget command.
 
 0.33.1 (*2020-09-04*)
 =====================

--- a/doc/cmd_other.rst
+++ b/doc/cmd_other.rst
@@ -132,6 +132,11 @@ If you do not specify any task, the default tasks are "*forget*".
 
   *doit* keeps track of which tasks are successful in the file ``.doit.db``.
 
+.. note::
+
+  If your default tasks are expensive, you can avoid accidentally forgetting
+  all of your default tasks by setting ``disable_default_all = True`` in
+  ``doit.cfg``. You can then do ``doit forget --all`` to forget default tasks.
 
 
 clean

--- a/doit/cmd_forget.py
+++ b/doit/cmd_forget.py
@@ -11,21 +11,44 @@ opt_forget_taskdep = {
     'help': 'forget task dependencies too',
     }
 
+opt_disable_default_all = {
+    'name': 'disable_default_all',
+    'long': 'disable-default-all',
+    'type': bool,
+    'default': False,
+    'help': 'disable forgetting all tasks by default',
+    }
+
+opt_forget_all = {
+    'name': 'forget_all',
+    'short': 'a',
+    'long': 'all',
+    'type': bool,
+    'default': False,
+    'help': 'forget all tasks if --disable-default-all is passed',
+    }
+
+
 
 class Forget(DoitCmdBase):
     doc_purpose = "clear successful run status from internal DB"
     doc_usage = "[TASK ...]"
     doc_description = None
 
-    cmd_options = (opt_forget_taskdep, )
+    cmd_options = (opt_forget_taskdep, opt_disable_default_all, opt_forget_all)
 
-    def _execute(self, forget_sub):
+    def _execute(self, forget_sub, disable_default_all, forget_all):
         """remove saved data successful runs from DB
         """
         # no task specified. forget all
-        if not self.sel_tasks:
+        # if --disable-default-all passed then --all must be passed too
+        if not self.sel_tasks and (not disable_default_all or forget_all):
             self.dep_manager.remove_all()
             self.outstream.write("forgetting all tasks\n")
+
+        elif not self.sel_tasks:
+             self.outstream.write(
+                 "no tasks specified, pass --all to forget all tasks\n")
 
         # forget tasks from list
         else:


### PR DESCRIPTION
I have a very large data analysis project that uses doit to analyze large data sets and cache the results of those analyses in pickle files, which are then loaded and used for plotting downstream. Doit handles this task perfectly. It's hard to overstate how much time doit has saved me when working on this project. 

However, one instance where doit has cost me time is when I have accidentally done `doit forget` with no arguments. I know that this forgets everything, but it is common for me to change a plotting task then forget it, and run it. When I'm tired, sometimes I press enter early when trying to forget the plotting task, which ends up forgetting tasks that cache analyses that take hours.

My solution to that is to force users to opt in to forgetting all tasks with an `-a/--all` flag (e.g., `doit forget --all`). I've implemented this in this PR, but I haven't yet filled out the changelog or added tests because I wanted to be sure that you would be okay with this change first @schettino72. If you're okay with it, then I will add those to this PR.