### PR TITLE
Use uniform date format for TaskResult to_dict()

### DIFF
--- a/doit/reporter.py
+++ b/doit/reporter.py
@@ -177,7 +177,7 @@ class TaskResult(object):
         """convert result data to dictionary"""
         if self._started_on is not None:
             started = datetime.datetime.utcfromtimestamp(self._started_on)
-            self.started = str(started)
+            self.started = str(started.strftime('%Y-%m-%d %H:%M:%S.%f'))
             self.elapsed = self._finished_on - self._started_on
         return {'name': self.task.name,
                 'result': self.result,


### PR DESCRIPTION
Standard datetime to string conversion leaves open the possibility that in case of µs = 0, no decimals are displayed, which could break conversion back to datetime based on standard format.