### PR TITLE
add codecov, tweak some spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ matrix.python-version }}-
             ${{ runner.os }}-pip-
-      - run: pip install . -r dev_requirements.txt python-coveralls
+      - run: pip install . -r dev_requirements.txt codecov
       - run: pip freeze
       - run: pip check
       - run: doit pyflakes
@@ -49,4 +49,4 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu' && matrix.python-version == '3.8' }}
         run: |
           doit coverage
-          coveralls || echo "TODO: remove when run on a repo that is set up"
+          codecov

--- a/README.rst
+++ b/README.rst
@@ -231,5 +231,5 @@ contributing
 
 On github create pull requests using a named feature branch.
 
-Financial contribution to support maitanance welcome.
+Financial contribution to support maintenance welcome.
 https://xscode.com/schettino72/doit

--- a/doc/dictionary.txt
+++ b/doc/dictionary.txt
@@ -447,6 +447,7 @@ task1
 task2
 taskorder
 taskresult
+TaskResult
 tasks'
 teardown
 time'


### PR DESCRIPTION
A follow-up to https://github.com/pydoit/doit/pull/379#pullrequestreview-611689406, this uploads coverage to `codecov`, which is slightly simpler to set up, and doesn't require a secret token.

Also fixes a few spelling issues, just so we can see all the :heavy_check_mark: .