### PR TITLE
Pass pickled attributes, err and out on failure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@
  * Niko Wenselowski - https://github.com/okin
  * Jan Felix Langenbach - o <dot> hase3 <at> gmail <dot> com
  * Facundo Ciccioli - facundofc <at> gmail <dot> com
+ * Alexandre Allard - https://github.com/alexandre-allard-scality

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Changes
 - python 3.9 support
 - Fix #381: Allow Delayed tasks to be executed multiple times in same process.
 - Fix #382: TaskResult make sure `started` include microsecond as decimal number.
+- Fix #387: Pass pickled attributes, err and out when a task fails in multi processes context.
 
 
 0.33.1 (*2020-09-04*)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pickle
 from multiprocessing import Queue
 import platform
@@ -26,7 +27,10 @@ def _error():
 def _exit():
     raise SystemExit()
 def simple_result():
+    print("simple output")
+    print("simple error", file=sys.stderr)
     return 'my-result'
+
 
 class FakeReporter(object):
     """Just log everything in internal attribute - used on tests"""
@@ -793,7 +797,13 @@ class TestMRunner_execute_task(object):
         run.finish()
         # check result
         assert result_q.get() == {'name': 't1', 'reporter': 'execute_task'}
-        assert result_q.get()['task']['result'] == 'my-result'
+        res = result_q.get()
+        assert res['task']['result'] == 'my-result'
+        # check task attributes are pickled
+        assert res['task']['executed']
+        # check stdout and stderr are passed
+        assert res['out'] == ['simple output\n']
+        assert res['err'] == ['simple error\n']
         assert result_q.empty()
 
 


### PR DESCRIPTION
In multi processes context, the pickled attributes,
stderr and stdout were not returned in case of
TaskError or TaskFailed, thus making it hard to see
what gone wrong when a command exits in error.

Refs: #387