### PR TITLE
Update version on home page

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -390,8 +390,8 @@
           <div class="heading text-center">
             <h2>Status</h2>
           </div>
-          <p class="lead"><code>doit</code> is under active development. Version 0.32 released on 2019-12.</p>
-          <p><em>doit</em> runs on Python 3.4 through 3.6 (including PyPy).
+          <p class="lead"><code>doit</code> is under active development. Version 0.33.1 released on 2020-09.</p>
+          <p><em>doit</em> runs on Python 3.5 through 3.8 (including PyPy).
             For python 2 support please use <em>doit</em> version <code>0.29</code>.
           <p>This <a href="http://schettino72.wordpress.com/2008/04/14/doit-a-build-tool-tale">blog post</a> explains how everything started in 2008.</p>
           <p><em>doit</em> core features are quite stable. If there is no recent development, it does NOT mean the project is not being maintained... The project has 100% unit-test code coverage.</p>


### PR DESCRIPTION
Having a release from 2019 makes it seem less active than the project is.
Python version range is updated to what was supported according to the build jobs at the time of the release.