### PR TITLE
Allow database-less execution, considering only file_dep and target mtimes

### DIFF
--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -8,7 +8,7 @@ from .globals import Globals
 from . import version
 from .cmdparse import CmdOption, CmdParse
 from .exceptions import InvalidCommand, InvalidDodoFile
-from .dependency import CHECKERS, DbmDB, JsonDB, SqliteDB, Dependency, JSONCodec
+from .dependency import CHECKERS, DbmDB, JsonDB, TemporaryDB, SqliteDB, Dependency, JSONCodec
 from .action import CmdAction
 from .plugin import PluginDict
 from . import loader
@@ -524,7 +524,7 @@ class DoitCmdBase(Command):
 
     def get_backends(self):
         """return PluginDict of DB backends, including core and plugins"""
-        backend_map = {'dbm': DbmDB, 'json': JsonDB, 'sqlite3': SqliteDB}
+        backend_map = {'dbm': DbmDB, 'json': JsonDB, 'temp': TemporaryDB, 'sqlite3': SqliteDB}
         # add plugins
         plugins = PluginDict()
         plugins.add_plugins(self.config, 'BACKEND')

--- a/doit/cmd_base.py
+++ b/doit/cmd_base.py
@@ -8,7 +8,7 @@ from .globals import Globals
 from . import version
 from .cmdparse import CmdOption, CmdParse
 from .exceptions import InvalidCommand, InvalidDodoFile
-from .dependency import CHECKERS, DbmDB, JsonDB, TemporaryDB, SqliteDB, Dependency, JSONCodec
+from .dependency import CHECKERS, DbmDB, JsonDB, SqliteDB, Dependency, JSONCodec
 from .action import CmdAction
 from .plugin import PluginDict
 from . import loader
@@ -524,7 +524,7 @@ class DoitCmdBase(Command):
 
     def get_backends(self):
         """return PluginDict of DB backends, including core and plugins"""
-        backend_map = {'dbm': DbmDB, 'json': JsonDB, 'temp': TemporaryDB, 'sqlite3': SqliteDB}
+        backend_map = {'dbm': DbmDB, 'json': JsonDB, 'sqlite3': SqliteDB}
         # add plugins
         plugins = PluginDict()
         plugins.add_plugins(self.config, 'BACKEND')

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -47,55 +47,6 @@ def get_file_md5(path):
     return md5.hexdigest()
 
 
-class TemporaryDB(object):
-    """Forgetful backend, in-memory only."""
-
-    def __init__(self, name, codec):
-        """Open/create a DB file"""
-        self._db = {}
-        self.name = name
-        self.codec = codec
-
-    def _load(self):
-        """load db content"""
-        pass
-
-    def dump(self):
-        """save DB content in file"""
-        pass
-
-    def set(self, task_id, dependency, value):
-        """Store value in the DB."""
-        if task_id not in self._db:
-            self._db[task_id] = {}
-        self._db[task_id][dependency] = value
-
-
-    def get(self, task_id, dependency):
-        """Get value stored in the DB.
-
-        @return: (string) or (None) if entry not found
-        """
-        if task_id in self._db:
-            return self._db[task_id].get(dependency, None)
-
-
-    def in_(self, task_id):
-        """@return bool if task_id is in DB"""
-        return task_id in self._db
-
-
-    def remove(self, task_id):
-        """remove saved dependencies from DB for taskId"""
-        if task_id in self._db:
-            del self._db[task_id]
-
-    def remove_all(self):
-        """remove saved dependencies from DB for all tasks"""
-        self._db = {}
-
-
-
 class JSONCodec():
     """default implmentation for codec used to save individual task's data"""
     def __init__(self):

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -80,6 +80,23 @@ class config_changed(object):
 
 
 # uptodate
+def targets_uptodate(task, values):
+    """check if target files exist and are not older than the dependencies
+    """
+    targets = task.targets
+    dependencies = task.file_dep
+    
+    # if one target is missing, is not uptodate
+    if any(not os.path.exists(target) for target in targets):
+        return False
+    # if one dependency is newer than a target, is not uptodate
+    newest_dependency_time = max(os.path.getmtime(dep) for dep in dependencies)
+    oldest_target_time = min(os.path.getmtime(target) for target in targets)
+    target_is_newer = not (newest_dependency_time > oldest_target_time)
+    return target_is_newer
+
+
+# uptodate
 class timeout(object):
     """add timeout to task
 

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -89,6 +89,9 @@ def targets_uptodate(task, values):
     # if one target is missing, is not uptodate
     if any(not os.path.exists(target) for target in targets):
         return False
+    # if not dependent on anything, and target is there, is uptodate
+    if len(dependencies) == 0:
+        return True
     # if one dependency is newer than a target, is not uptodate
     newest_dependency_time = max(os.path.getmtime(dep) for dep in dependencies)
     oldest_target_time = min(os.path.getmtime(target) for target in targets)


### PR DESCRIPTION
Dear all,

The attached patch allows using doit in a database-less fashion. Similar to make, only the file modification times of the target and file_deps as stored in the file system are used.

The patch introduces 

* a "no-op" database (TemporaryDB), which starts empty and does not store anything to disk. It can be selected with backend: "temp".
* a "no-op" checker (NoChecker), which always returns True. This required moving a None check (task not in database) from the generic code into the other checkers.
* a uptodate function (targets_uptodate), which checks that the output files are newer than the dependent files.

This enables the way I would like to use doit. I hope it is of interest to you as well.

Below is an example dodo.py file which demonstrates the usage / configuration.

```
from doit.tools import targets_uptodate

def task_create_bar():
    return {
        'actions': ['echo creating bar', 'wc -l dodo.py > bar'],
        'targets': ['bar'],
        'file_dep': ['dodo.py'],
        'uptodate': [targets_uptodate],
        }

def task_create_foo():
    return {
        'actions': ['echo creating foo', 'cp bar foo', 'chmod 750 foo'],
        'targets': ['foo'],
        'file_dep': ['bar'],
        'uptodate': [targets_uptodate],
        }

DOIT_CONFIG = {
	'backend': 'temp',
        'check_file_uptodate': 'none',
}
```