### PR TITLE
Add field 'meta' to tasks that can be used by plugins

### DIFF
--- a/doit/cmd_info.py
+++ b/doit/cmd_info.py
@@ -50,6 +50,7 @@ class Info(DoitCmdBase):
             ('params', 'list'),
             ('verbosity', 'scalar'),
             ('watch', 'list'),
+            ('meta', 'dict')
         )
 
         self.outstream.write('\n{}\n'.format(task.name))

--- a/doit/task.py
+++ b/doit/task.py
@@ -154,6 +154,7 @@ class Task(object):
                   'getargs': ((dict,), ()),
                   'title': ((Callable,), (None,)),
                   'watch': ((list, tuple), ()),
+                  'meta': ((dict,), {})
                   }
 
 
@@ -163,7 +164,7 @@ class Task(object):
                  subtask_of=None, has_subtask=False,
                  doc=None, params=(), pos_arg=None,
                  verbosity=None, title=None, getargs=None,
-                 watch=(), loader=None):
+                 watch=(), meta = {}, loader=None):
         """sanity checks and initialization
 
         @param params: (list of dict for parameters) see cmdparse.CmdOption
@@ -189,6 +190,7 @@ class Task(object):
         self.check_attr(name, 'getargs', getargs, self.valid_attr['getargs'])
         self.check_attr(name, 'title', title, self.valid_attr['title'])
         self.check_attr(name, 'watch', watch, self.valid_attr['watch'])
+        self.check_attr(name, 'meta', meta, self.valid_attr['meta'])
 
         if '=' in name:
             msg = "Task '{}': name must not use the char '=' (equal sign)."
@@ -243,6 +245,7 @@ class Task(object):
         self.teardown = [create_action(a, self, 'teardown') for a in teardown]
         self.doc = self._init_doc(doc)
         self.watch = watch
+        self.meta = meta
         # just indicate if actions were executed at all
         self.executed = False
 

--- a/tests/test_cmd_info.py
+++ b/tests/test_cmd_info.py
@@ -13,7 +13,8 @@ class TestCmdInfo(object):
     def test_info_basic_attrs(self, dep_manager):
         output = StringIO()
         task = Task("t1", [], file_dep=['tests/data/dependency1'],
-                    doc="task doc", getargs={'a': ('x', 'y')}, verbosity=2)
+                    doc="task doc", getargs={'a': ('x', 'y')}, verbosity=2,
+                    meta={'a': ['b', 'c']})
         cmd = CmdFactory(Info, outstream=output,
                          dep_file=dep_manager.name, task_list=[task])
         cmd._execute(['t1'], hide_status=True)
@@ -22,6 +23,7 @@ class TestCmdInfo(object):
         assert "- tests/data/dependency1" in output.getvalue()
         assert "verbosity  : 2" in output.getvalue()
         assert "getargs    : {'a': ('x', 'y')}" in output.getvalue()
+        assert "meta       : {'a': ['b', 'c']}" in output.getvalue()
 
     def test_invalid_command_args(self, dep_manager):
         output = StringIO()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -68,6 +68,10 @@ class TestLoadTasks(object):
         def task_yyy2():
             return {'actions':None}
 
+        def task_meta():
+            return {'actions' : ['do nothing'],
+                    'meta'    : { 'a' : ['b', 'c']}}
+        
         def bad_seed(): pass
         task_nono = 5
         task_nono # pyflakes
@@ -75,9 +79,10 @@ class TestLoadTasks(object):
 
     def testNormalCase(self, dodo):
         task_list = load_tasks(dodo)
-        assert 2 == len(task_list)
+        assert 3 == len(task_list)
         assert 'xxx1' == task_list[0].name
         assert 'yyy2' == task_list[1].name
+        assert 'meta' == task_list[2].name
 
     def testCreateAfterDecorator(self):
         @create_after('yyy2')
@@ -145,6 +150,10 @@ class TestLoadTasks(object):
         task_list = load_tasks(dodo)
         assert "task doc" == task_list[0].doc
 
+    def testMetaInfo(self, dodo):
+        task_list = load_tasks(dodo)
+        assert task_list[2].meta == {'a': ['b', 'c']}
+        
     def testUse_create_doit_tasks(self):
         def original(): pass
         def creator():


### PR DESCRIPTION
The field is not interpreted by doit, but it can be used by plugins

A proposal according to the [conversation on the mailing list](https://groups.google.com/g/python-doit/c/nGzyDvD9QHc/m/qYjGc_clAAAJ). 

I am not sure about the name of the field. "meta" is a bit abstract, but it is short. Any other suggestions?
Maybe "hints"? Or "plugins"...?

Also I don't know where to put this in the docs...