### PR TITLE
create class variable to hold config file entries prefix

### DIFF
--- a/doit/doit_cmd.py
+++ b/doit/doit_cmd.py
@@ -52,6 +52,9 @@ class DoitConfig():
     _TOML_LIBS = ['toml', 'tomlkit']
     PLUGIN_TYPES = ['command', 'loader', 'backend', 'reporter']
 
+    # configuration file entry prefix
+    PREFIX = 'tool.doit'
+
     def __init__(self):
         self._toml = None
         self.config = defaultdict(dict)
@@ -59,7 +62,7 @@ class DoitConfig():
     def loads(self, config_filenames):
         for config_filename in config_filenames:
             if str(config_filename).lower().endswith('.toml'):
-                prefix = 'tool.doit' if config_filename == 'pyproject.toml' else ''
+                prefix = self.PREFIX if config_filename == 'pyproject.toml' else ''
                 toml_config = self.load_config_toml(config_filename, prefix)
                 for section in toml_config:
                     self.config[section].update(toml_config[section].items())


### PR DESCRIPTION
I intend to customize the configuration file entries prefix (e.g.tool.myapp.tasks.make_cookies instead of tool.doit.tasks.make_cookies). However, there is no global setting to replace all "doit" references with my own application name. Therefore i ended up creating a class variable that i can later modify without having to subclass DoitMain and DoitConfig classes.