### PR TITLE
support tomli and make it the default TOML provider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@
  * Facundo Ciccioli - facundofc <at> gmail <dot> com
  * Alexandre Allard - https://github.com/alexandre-allard-scality
  * Trevor Bekolay - https://github.com/tbekolay
+ * Michał Górny - https://github.com/mgorny

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,4 +6,4 @@ pyflakes
 pytest>=5.4.1
 coverage>=4.0,<5
 doit-py>=0.4.0
-toml>=0.10.1
+tomli; python_version<"3.11"

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -33,11 +33,14 @@ This is the preferred configuration source, and may gain features not available 
 
 .. note::
 
-   As a TOML parser is _not_ yet part of the standard library, a third-party package is
+   A TOML parser (`PEP 680 <https://peps.python.org/pep-0680/` / `tomllib
+   <https://docs.python.org/3.11/library/tomllib.html>`) is part of the standard
+   library since Python 3.11. For earlier Python versions, a third-party package is
    required, one of:
 
-   - `toml <https://pypi.org/project/toml/>`__
+   - `tomli <https://pypi.org/project/tomli/>`__
    - `tomlkit <https://pypi.org/project/tomlkit/>`_
+   - `toml <https://pypi.org/project/toml/>`__
 
 
 TOML vs INI

--- a/doc/dictionary.txt
+++ b/doc/dictionary.txt
@@ -478,7 +478,9 @@ to's
 toc
 toctree
 toml
+tomli
 tomlkit
+tomllib
 toolchain
 toolchains
 traceback

--- a/doit/doit_cmd.py
+++ b/doit/doit_cmd.py
@@ -49,7 +49,7 @@ def set_var(name, value):
 class DoitConfig():
     """Parse and store values taken from INI and TOML configuration files"""
     # support TOML python libs
-    _TOML_LIBS = ['toml', 'tomlkit']
+    _TOML_LIBS = ['tomllib', 'tomli', 'tomlkit', 'toml']
     PLUGIN_TYPES = ['command', 'loader', 'backend', 'reporter']
 
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(name = 'doit',
           ':sys.platform == "darwin"': ['macfsevents'],
           ':sys.platform == "linux"': ['pyinotify'],
           'plugins': ['setuptools'],
-          'toml': ['toml >=0.10.1']
+          'toml': ['tomli; python_version<"3.11"']
       },
       long_description = long_description,
       entry_points = {


### PR DESCRIPTION
Add support for the modern `tomli` module and specify it in dependency
files instead of the obsolete `toml` library.  `tomli` is the common
choice among new Python projects and unlike `toml`, it implements
TOML 1.0.