### PR TITLE
Update file dependencies for up-to-date tasks.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Changes
 0.37.0 (*unreleased*)
 ======================
 
+- update timestamps of file dependencies even if the task is already up to date.
+
 
 0.36.0 (*2022-04-22*)
 =====================
@@ -607,4 +609,3 @@ Changes
 ====================
 
 - initial release
-

--- a/doit/dependency.py
+++ b/doit/dependency.py
@@ -541,12 +541,19 @@ class Dependency(object):
             else:
                 self._set(task.name, "result:", get_md5(task.result))
 
+        self.update_deps(task)
+
+    def update_deps(self, task, ignore_missing=False):
         # file-dep
         self._set(task.name, 'checker:', self.checker.__class__.__name__)
         for dep in task.file_dep:
-            state = self.checker.get_state(dep, self._get(task.name, dep))
-            if state is not None:
-                self._set(task.name, dep, state)
+            try:
+                state = self.checker.get_state(dep, self._get(task.name, dep))
+                if state is not None:
+                    self._set(task.name, dep, state)
+            except FileNotFoundError:
+                if not ignore_missing:
+                    raise
 
         # save list of file_deps
         self._set(task.name, 'deps:', tuple(task.file_dep))

--- a/doit/runner.py
+++ b/doit/runner.py
@@ -215,6 +215,7 @@ class Runner():
                 break
 
             if not self.select_task(node, task_dispatcher.tasks):
+                self.dep_manager.update_deps(node.task, ignore_missing=True)
                 continue
 
             base_fail = self.execute_task(node.task)


### PR DESCRIPTION
This PR updates file dependencies in the doit database even if the task is already up to date. The change improves performance for large files under certain circumstances.

Consider the following task which simply copies `large_file.txt` to `output.txt`.

```python
def task_copy():
    return {
        "actions": ["cp large_file.txt output.txt"],
        "targets": ["output.txt"],
        "file_dep": ["large_file.txt"],
    }
```

The first time doit runs, it saves the timestamp, size, and md5 hash. On the second run, doit smartly skips calculating the md5 hash of `large_file.txt` because the timestamps match. So far so good.

Now suppose the timestamp changes but the content does not. This might happen if we delete an intermediate file which is then regenerated. On the second run, doit will evaluate the md5 on `large_file.txt` and skip the task because it's up to date--as expected. But it won't update the timestamp in the database. So every time we run doit, it'll evaluate the md5 hash of `large_file.txt`. 

This PR ensures the file dependencies are updated in the database even if the task is already up to date. Here's a concrete example using `touch` to update the timestamp. I've modified the `check_modified` function to report some debugging information (see end of description for details).

```bash
$ (master) rm -f .doit.db  # Start clean.
$ (master) doit
.  copy
$ (master) doit
-- copy
$ (master) touch large_file.txt
$ (master) doit
large_file.txt was modified at 15:53:09.664308; expected 15:51:36.076443
-- copy
$ (master) doit  # Evaluates md5 hash again (and will indefinitely).
large_file.txt was modified at 15:53:09.664308; expected 15:51:36.076443
-- copy
```

```bash
$ (check_modified) rm -f .doit.db  # Start clean.
$ (check_modified) doit
.  copy
$ (check_modified) doit
-- copy
$ (check_modified) touch large_file.txt
$ (check_modified) doit
large_file.txt was modified at 15:51:36.076443; expected 15:49:30.170537
-- copy
$ (check_modified) doit  # Does not evaluate md5 hash again (updated timestamp saved in previous run).
-- copy
```


# Updated check_modified to report debug information.

```python
    def check_modified(self, file_path, file_stat, state):
        """
        Check if file in file_path is modified from previous "state".
        """
        timestamp, size, file_md5 = state

        # 1 - if timestamp is not modified file is the same
        if file_stat.st_mtime == timestamp:
            return False

        from datetime import datetime
        print(f"{file_path} was modified at {datetime.fromtimestamp(file_stat.st_mtime).time()}; "
              f"expected {datetime.fromtimestamp(timestamp).time()}")

        # 2 - if size is different file is modified
        if file_stat.st_size != size:
            return True

        # 3 - check md5
        return file_md5 != get_file_md5(file_path)
```