### PR TITLE
Correct title.py

### DIFF
--- a/doc/samples/title.py
+++ b/doc/samples/title.py
@@ -1,6 +1,6 @@
 
 def show_cmd(task):
-    return "executing... %s" % task.name
+    return "executing... %s" % task.actions[0]
 
 def task_custom_display():
     return {'actions':['echo abc efg'],


### PR DESCRIPTION
As far as I can tell, `doc/samples/title.py` is only used on the [tasks doc page](https://github.com/pydoit/doit/blob/master/doc/tasks.rst).

The **expected** output of `title.py`, as specified on the tasks page, is:

```
$ doit
.  executing... Cmd: echo abc efg
```

However, the **actual** output (before my proposed change) is:

```
doit                        
.  executing... custom_display
```