### PR TITLE
Fix executing script name on Windows

### DIFF
--- a/doit/doit_cmd.py
+++ b/doit/doit_cmd.py
@@ -152,7 +152,7 @@ class DoitConfig():
 
 class DoitMain(object):
     # core doit commands
-    BIN_NAME = sys.argv[0].split('/')[-1]
+    BIN_NAME = os.path.split(sys.argv[0])[-1]
     DOIT_CMDS = (Help, Run, List, Info, Clean, Forget, Ignore, DumpDB,
                  Strace, TabCompletion, ResetDep)
 


### PR DESCRIPTION
Hello, first time contributor. This is a lovely project. On Windows, and specifically when installed via conda, `doit --help` displays the path of the entire executing script (see below). This PR corrects that by using `os.path.split` vice `.split('/')`. Question: why not just display the name as `doit`? It looks like there was considerable thought behind persevering the name of the executing script, I was curious as to its use case.

```shell
❯ doit --help 
doit -- automation tool
http://pydoit.org

Commands
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py clean             clean action / remove targets
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py dumpdb            dump dependency DB
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py forget            clear successful run status from internal DB
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py help              show help
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py ignore            ignore task (skip) on subsequent runs
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py info              show info about a task
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py list              list tasks from dodo file
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py reset-dep         recompute and save the state of file dependencies without executing actions
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py run               run tasks
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py strace            use strace to list file_deps and targets
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py tabcompletion     generate script for tab-completion

  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py help              show help / reference
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py help task         show help on task dictionary fields
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py help <command>    show command usage
  C:\Users\Charles\AppData\Local\mambaforge\Scripts\doit-script.py help <task-name>  show task usage
```