### PR TITLE
Added __repr__ to the config_changes and result_dep classes.

### DIFF
--- a/doit/task.py
+++ b/doit/task.py
@@ -672,3 +672,6 @@ class result_dep(UptodateCalculator):
         if last_success is None:
             return False
         return last_success == dep_result
+
+    def __repr__(self):
+        return 'result_dep("%s")' % self.dep_name

--- a/doit/tools.py
+++ b/doit/tools.py
@@ -79,6 +79,9 @@ class config_changed(object):
             return False
         return (last_success == self.config_digest)
 
+    def __repr__(self):
+        return "config_changed(%r)" % self.config
+
 
 
 # uptodate


### PR DESCRIPTION
I added some basic `__repr__` implementations to the `config_changed` and `result_dep` classes. I needed a nicer representation for these so that I could better understand the output of the `info` command. 

If these particular implementations aren't acceptable for some reason, let me know what you'd prefer.